### PR TITLE
Add publish readiness validation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -48,11 +48,12 @@
 ## Skill Packaging
 
 - Keep YAML frontmatter valid in skill files. The `name` should match the skill folder, and descriptions should include concrete trigger phrases.
-- Do not add runtime dependencies, build tooling, or generated artifacts unless the task explicitly requires them. This package currently has metadata and validation scripts only in `package.json`.
+- Do not add runtime dependencies, build tooling, or generated artifacts unless the task explicitly requires them. This package currently has metadata plus dev-only validation and lint scripts in `package.json`.
 - Favor Markdown-only changes for workflow updates. Add scripts or tests only when they create a real validation path for future maintainers.
 
 ## Validation
 
+- Run `npm run lint` after changing JavaScript validation scripts or lint configuration.
 - Run `npm run validate` before publishing or after changing `README.md`, `package.json`, `penpot-mcp/SKILL.md`, or reference docs.
 - For Markdown-only edits, run `git diff --check -- <changed-files>` to catch whitespace issues and inspect the focused diff for accuracy.
 - For `package.json` edits, also validate JSON parsing with Node or npm before finishing.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -9,4 +9,51 @@
 - **Active plugins**: none
 
 ---
+
 <!-- USER INSTRUCTIONS BELOW THIS LINE — preserved across re-generation runs -->
+
+# Project Guidelines
+
+## Repository Purpose
+
+- This repository packages the `penpot-mcp` agent skill. Treat it as documentation and workflow content for AI agents, not as a JavaScript application runtime.
+- Keep `penpot-mcp/SKILL.md` as the concise always-loaded core. Put longer task recipes, API details, and examples in `penpot-mcp/references/*.md`.
+- Keep `README.md`, `package.json`, and `penpot-mcp/SKILL.md` aligned when changing the public description, supported workflows, tool list, install guidance, or release metadata.
+
+## Source Layout
+
+- `penpot-mcp/SKILL.md`: trigger description, setup guidance, safety workflow, common prompts, and critical gotchas.
+- `penpot-mcp/references/penpot-api-patterns.md`: authoritative Penpot plugin API patterns, JavaScript examples, and low-level gotchas.
+- `penpot-mcp/references/design-system-workflows.md`: design system creation, audit, migration, and component library workflows.
+- `penpot-mcp/references/design-to-code-workflows.md`: HTML/CSS, React, token extraction, asset export, and design-code sync workflows.
+- `penpot-mcp/references/prototyping-workflows.md`: flows, overlays, interactions, animations, and prototype audit workflows.
+
+## Authoring Style
+
+- Write for AI agents. Prefer direct, imperative, testable rules such as "Always", "Never", "Use when", and "Verify".
+- Keep instructions compact and scannable with headings, checklists, tables, and fenced examples. Move long explanations to reference files instead of expanding `SKILL.md`.
+- Preserve exact Penpot MCP tool names: `high_level_overview`, `penpot_api_info`, `execute_code`, `export_shape`, and `import_image`.
+- Use deterministic examples: stable names, explicit input/output formats, compact JSON schemas, and clear pause or approval points.
+- When changing a rule or gotcha, search nearby docs for duplicated guidance and update related mentions so the skill does not contradict itself.
+
+## Penpot MCP Invariants
+
+- Always inspect first with `penpot_api_info` or `high_level_overview`; only guide setup when the connection check fails.
+- Follow the read, plan, write, verify workflow for Penpot changes. Describe intended writes before applying them.
+- Keep writes in small batches, usually 5 to 10 shape operations per `execute_code` call, and verify structurally after each batch.
+- Never switch pages and write in the same `execute_code` call. Use one call for `penpot.openPage(...)`, then a separate call for writes.
+- Verify via the Penpot API and structure reads. Treat `export_shape` as best-effort because it can fail over HTTP.
+- Preserve documented API gotchas: use `resize()` for shape size, `penpotUtils.setParentXY()` for parented coordinates, `insertChild()` for z-order, guard nullable `penpot.createText(...)` results before resizing or styling, reset text `growType` after resize, and keep typography numeric fields as strings where documented.
+
+## Skill Packaging
+
+- Keep YAML frontmatter valid in skill files. The `name` should match the skill folder, and descriptions should include concrete trigger phrases.
+- Do not add runtime dependencies, build tooling, or generated artifacts unless the task explicitly requires them. This package currently has metadata and validation scripts only in `package.json`.
+- Favor Markdown-only changes for workflow updates. Add scripts or tests only when they create a real validation path for future maintainers.
+
+## Validation
+
+- Run `npm run validate` before publishing or after changing `README.md`, `package.json`, `penpot-mcp/SKILL.md`, or reference docs.
+- For Markdown-only edits, run `git diff --check -- <changed-files>` to catch whitespace issues and inspect the focused diff for accuracy.
+- For `package.json` edits, also validate JSON parsing with Node or npm before finishing.
+- If examples include JavaScript intended for `execute_code`, check them against `penpot-mcp/references/penpot-api-patterns.md` before publishing.

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,26 @@
+name: Validate
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "20"
+
+      - name: Validate package
+        run: npm run validate
+
+      - name: Check diff whitespace
+        run: npm run check:whitespace

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: "20"
+          node-version: "20.19.0"
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -21,5 +21,11 @@ jobs:
         with:
           node-version: "20"
 
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint scripts
+        run: npm run lint
+
       - name: Validate package
         run: npm run validate

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -21,6 +23,3 @@ jobs:
 
       - name: Validate package
         run: npm run validate
-
-      - name: Check diff whitespace
-        run: npm run check:whitespace

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -27,5 +27,8 @@ jobs:
       - name: Lint scripts
         run: npm run lint
 
+      - name: Check formatting
+        run: npm run format:check
+
       - name: Validate package
         run: npm run validate

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+*.md
+node_modules/

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![Agent Skills](https://img.shields.io/badge/npx_skills_add-ar27111994%2Fpenpot--mcp-8B5CF6)](https://github.com/ar27111994/penpot-mcp)
 [![skills.sh](https://skills.sh/b/ar27111994/penpot-mcp)](https://skills.sh/ar27111994/penpot-mcp)
-[![GitHub tag](https://img.shields.io/github/v/tag/ar27111994/penpot-mcp?sort=semver&logo=github)](https://github.com/ar27111994/penpot-mcp/tags)
+[![Version](https://img.shields.io/github/package-json/v/ar27111994/penpot-mcp?label=version)](https://github.com/ar27111994/penpot-mcp)
 
 > AI-agent skill for creating, auditing, and maintaining production-grade design projects and design systems — including flows, interactions, animations, and overlays — in [Penpot](https://penpot.app) via the official [Penpot MCP Server](https://help.penpot.app/mcp/).
 
@@ -47,7 +47,7 @@ gh skills install ar27111994/penpot-mcp
 
 ```text
 penpot-mcp/
-├── SKILL.md                                ← Always-loaded core (~340 lines)
+├── SKILL.md                                ← Always-loaded core
 └── references/
     ├── penpot-api-patterns.md              ← JS API, gotchas, fonts, interactions, animations
     ├── prototyping-workflows.md            ← Flows, overlays, audit, lo-fi→hi-fi
@@ -79,4 +79,3 @@ PRs welcome — especially for new workflow recipes, additional platform templat
 ## License
 
 MIT
-

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,26 @@
+const nodeGlobals = {
+  console: "readonly",
+  process: "readonly",
+};
+
+export default [
+  {
+    ignores: ["node_modules/**"],
+  },
+  {
+    files: ["eslint.config.mjs", "scripts/**/*.mjs"],
+    languageOptions: {
+      ecmaVersion: "latest",
+      sourceType: "module",
+      globals: nodeGlobals,
+    },
+    rules: {
+      eqeqeq: "error",
+      "no-constant-condition": "error",
+      "no-undef": "error",
+      "no-unreachable": "error",
+      "no-unused-vars": "error",
+      "valid-typeof": "error",
+    },
+  },
+];

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.4.0",
       "license": "MIT",
       "devDependencies": {
-        "eslint": "^10.4.0"
+        "eslint": "^10.4.0",
+        "prettier": "^3.8.3"
       },
       "engines": {
         "node": ">=20"
@@ -781,6 +782,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/punycode": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,882 @@
+{
+  "name": "penpot-mcp",
+  "version": "1.4.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "penpot-mcp",
+      "version": "1.4.0",
+      "license": "MIT",
+      "devDependencies": {
+        "eslint": "^10.4.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.23.5",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
+      "integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^3.0.5",
+        "debug": "^4.3.1",
+        "minimatch": "^10.2.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.6.0.tgz",
+      "integrity": "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.2.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
+      "integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
+      "integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.1.tgz",
+      "integrity": "sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.2.1",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@types/esrecurse": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.4.0.tgz",
+      "integrity": "sha512-loXy6bWOoP3EP6JA7jo6p5jMpBJmHmsNZM5SFRHLdh1MGOPurMnNBj4ZlAbaqUAaQWbCr7jHV4P7gzAyryZWkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@eslint/config-array": "^0.23.5",
+        "@eslint/config-helpers": "^0.6.0",
+        "@eslint/core": "^1.2.1",
+        "@eslint/plugin-kit": "^0.7.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^9.1.2",
+        "eslint-visitor-keys": "^5.0.1",
+        "espree": "^11.2.0",
+        "esquery": "^1.7.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "minimatch": "^10.2.4",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+      "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@types/esrecurse": "^4.3.1",
+        "@types/estree": "^1.0.8",
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^5.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "lint": "eslint \"scripts/**/*.mjs\" eslint.config.mjs",
     "format:check": "prettier --check package.json package-lock.json eslint.config.mjs scripts/**/*.mjs .github/workflows/**/*.yml",
     "validate": "node scripts/validate-package.mjs",
-    "check:whitespace": "git diff --check -- .github README.md package.json penpot-mcp scripts"
+    "check:whitespace": "git diff --check -- .github README.md package.json penpot-mcp scripts && git diff --cached --check -- .github README.md package.json penpot-mcp scripts"
   },
   "author": "ar27111994",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,11 @@
 {
   "name": "penpot-mcp",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "AI-agent skill for creating, auditing, and maintaining production-grade Penpot design projects, design systems, flows, interactions, animations, tokens, and visual effects via the official Penpot MCP Server.",
+  "scripts": {
+    "validate": "node scripts/validate-package.mjs",
+    "check:whitespace": "git diff --check -- .github README.md package.json penpot-mcp scripts"
+  },
   "author": "ar27111994",
   "license": "MIT",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.4.0",
   "description": "AI-agent skill for creating, auditing, and maintaining production-grade Penpot design projects, design systems, flows, interactions, animations, tokens, and visual effects via the official Penpot MCP Server.",
   "scripts": {
+    "lint": "eslint \"scripts/**/*.mjs\" eslint.config.mjs",
     "validate": "node scripts/validate-package.mjs",
     "check:whitespace": "git diff --check -- .github README.md package.json penpot-mcp scripts"
   },
@@ -39,5 +40,8 @@
   "homepage": "https://github.com/ar27111994/penpot-mcp#readme",
   "bugs": {
     "url": "https://github.com/ar27111994/penpot-mcp/issues"
+  },
+  "devDependencies": {
+    "eslint": "^10.4.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "AI-agent skill for creating, auditing, and maintaining production-grade Penpot design projects, design systems, flows, interactions, animations, tokens, and visual effects via the official Penpot MCP Server.",
   "scripts": {
     "lint": "eslint \"scripts/**/*.mjs\" eslint.config.mjs",
+    "format:check": "prettier --check package.json package-lock.json eslint.config.mjs scripts/**/*.mjs .github/workflows/**/*.yml",
     "validate": "node scripts/validate-package.mjs",
     "check:whitespace": "git diff --check -- .github README.md package.json penpot-mcp scripts"
   },
@@ -42,6 +43,7 @@
     "url": "https://github.com/ar27111994/penpot-mcp/issues"
   },
   "devDependencies": {
-    "eslint": "^10.4.0"
+    "eslint": "^10.4.0",
+    "prettier": "^3.8.3"
   }
 }

--- a/penpot-mcp/SKILL.md
+++ b/penpot-mcp/SKILL.md
@@ -152,7 +152,7 @@ Before any setup steps, **call `penpot_api_info` or `high_level_overview` first*
 
 **Page switching — mandatory two-call pattern:**
 
-```
+```text
 Call N:   penpot.openPage(page)    ← switch page
 Call N+1: write/read on that page  ← write after switch
 ```
@@ -254,7 +254,7 @@ STYLE
 
 ### Token hierarchy
 
-```
+```text
 Tier 1 (Global):    color.base.neutral.100, spacing.base.8
 Tier 2 (Semantic):  color.bg.default, color.text.primary
 Tier 3 (Component): color.button.primary.bg

--- a/penpot-mcp/SKILL.md
+++ b/penpot-mcp/SKILL.md
@@ -39,6 +39,7 @@ MCP **always acts on the currently focused page** in the active Penpot browser t
 ## 1. Connection Setup
 
 ### Remote MCP (recommended for most users)
+
 1. Penpot → **Your account → Integrations → MCP Server** → enable
 2. Generate MCP key (shown once — store safely; only one key per user at a time)
 3. Copy server URL: `https://<your-penpot-domain>/mcp/stream?userToken=YOUR_MCP_KEY`
@@ -46,10 +47,12 @@ MCP **always acts on the currently focused page** in the active Penpot browser t
 5. Open a design file → **File → MCP Server → Connect**
 
 ### Local MCP (advanced; extra file-system access)
+
 ```bash
 npx @penpot/mcp@stable   # keep running; matches current Penpot release
 npx @penpot/mcp@beta     # for beta/test environments
 ```
+
 - Load plugin: **Plugins → Load from URL** → `http://localhost:4400/manifest.json`
 - Click **Connect to MCP server** in plugin UI → keep plugin window open at all times
 - Client URL: `http://localhost:4401/mcp` (no auth)
@@ -58,27 +61,49 @@ npx @penpot/mcp@beta     # for beta/test environments
 ### Client Config Snippets
 
 **Claude Code** (`.claude/settings.json`):
+
 ```json
-{ "mcpServers": { "penpot": { "transport": "http", "url": "REMOTE_OR_LOCAL_URL" } } }
+{
+  "mcpServers": {
+    "penpot": { "transport": "http", "url": "REMOTE_OR_LOCAL_URL" }
+  }
+}
 ```
+
 **Cursor**:
+
 ```json
 { "mcpServers": { "penpot": { "url": "REMOTE_OR_LOCAL_URL", "type": "http" } } }
 ```
+
 **VS Code / Copilot** (`settings.json`):
+
 ```json
-{ "mcp.servers": { "penpot": { "transport": "http", "url": "REMOTE_OR_LOCAL_URL" } } }
+{
+  "mcp.servers": {
+    "penpot": { "transport": "http", "url": "REMOTE_OR_LOCAL_URL" }
+  }
+}
 ```
+
 **Codex / OpenCode**:
+
 ```json
-{ "servers": { "penpot": { "url": "REMOTE_OR_LOCAL_URL", "transport": { "type": "http" } } } }
+{
+  "servers": {
+    "penpot": { "url": "REMOTE_OR_LOCAL_URL", "transport": { "type": "http" } }
+  }
+}
 ```
+
 **Claude Desktop** (stdio-only — requires proxy):
+
 ```bash
 npx -y mcp-remote http://localhost:4401/mcp --allow-http
 ```
 
 ### Troubleshooting Checklist
+
 - Restart MCP server process
 - Reconnect plugin (**File → MCP Server → Connect**)
 - Restart MCP client / reload tools
@@ -90,20 +115,22 @@ npx -y mcp-remote http://localhost:4401/mcp --allow-http
 
 ## 2. Available MCP Tools
 
-| Tool | Mode | Description |
-|------|------|-------------|
-| `high_level_overview` | Both | Read overall file structure, pages, layers, components |
-| `penpot_api_info` | Both | Query Penpot plugin API documentation |
-| `execute_code` | Both | Run JavaScript in Penpot plugin context — primary read/write tool |
-| `export_shape` | Both | Export shape as PNG/SVG (remote: limited; may fail with HTTP error) |
-| `import_image` | Local only | Import image from local file path into design |
+| Tool                  | Mode       | Description                                                         |
+| --------------------- | ---------- | ------------------------------------------------------------------- |
+| `high_level_overview` | Both       | Read overall file structure, pages, layers, components              |
+| `penpot_api_info`     | Both       | Query Penpot plugin API documentation                               |
+| `execute_code`        | Both       | Run JavaScript in Penpot plugin context — primary read/write tool   |
+| `export_shape`        | Both       | Export shape as PNG/SVG (remote: limited; may fail with HTTP error) |
+| `import_image`        | Local only | Import image from local file path into design                       |
 
 > Remote MCP cannot import images from local paths. `export_shape` may fail with HTTP errors — always verify structurally via API rather than relying on export success.
 
 ### Check connection first (always)
+
 Before any setup steps, **call `penpot_api_info` or `high_level_overview` first**. If it succeeds, skip setup entirely.
 
 ### JavaScript API
+
 `execute_code` runs JS against the Penpot plugin API. **Read `references/penpot-api-patterns.md` before any `execute_code` calls.** It covers the full API including tokens, library creation, page management, visual effects, storage, and idempotency helpers.
 
 ---
@@ -118,18 +145,22 @@ Before any setup steps, **call `penpot_api_info` or `high_level_overview` first*
 ```
 
 **Write call limits — enforce strictly:**
+
 - Max ~5–10 shape operations per `execute_code` call
 - Pause and verify between batches
 - Never "build everything" in one call — MCP writes time out on large batches, leaving partial updates with no error indication
 
 **Page switching — mandatory two-call pattern:**
+
 ```
 Call N:   penpot.openPage(page)    ← switch page
 Call N+1: write/read on that page  ← write after switch
 ```
-Page switching is asynchronous in the plugin bridge. Writing in the same call as `openPage` applies changes to the *previously* active page. Exception: calling `openPage` at the top of a call then immediately reading (not writing) can be reliable.
+
+Page switching is asynchronous in the plugin bridge. Writing in the same call as `openPage` applies changes to the _previously_ active page. Exception: calling `openPage` at the top of a call then immediately reading (not writing) can be reliable.
 
 **Use `storage` for large workflows:**
+
 ```javascript
 // Call 1: compute and store your design token data
 storage.tokenData = { colors: { primary: '#HEX' }, spacing: 8, ... };
@@ -139,6 +170,7 @@ const DS = storage.tokenData || fallback;
 ```
 
 **Starter prompts (always run first after connecting):**
+
 ```
 "List all pages in this file."
 "Show all components on this page."
@@ -150,6 +182,7 @@ const DS = storage.tokenData || fallback;
 ## 4. Role & Prompt Engineering
 
 ### Define the agent role precisely
+
 ```
 BAD:  "You are a creative designer."
 GOOD: "You are a Senior Product Designer expert in design systems, WCAG accessibility,
@@ -159,6 +192,7 @@ GOOD: "You are a Senior Product Designer expert in design systems, WCAG accessib
 ```
 
 ### Structured Brief Template
+
 ```
 CONTEXT: [product name, target user, current state of file]
 GOAL: [specific problem — e.g., "build design token system and foundations page"]
@@ -174,6 +208,7 @@ QUALITY CRITERIA: [how you'll know it's done]
 ```
 
 ### Negatives (always include)
+
 - "Do not invent colors not in the token set."
 - "Do not use font weights not confirmed installed for this font family."
 - "Do not switch page and write in the same execute_code call."
@@ -181,6 +216,7 @@ QUALITY CRITERIA: [how you'll know it's done]
 - "Do not create duplicate colors/typographies — always check before creating."
 
 ### Iteration pattern
+
 ```
 1. Discovery  → read all pages, library assets, tokens, existing components
 2. Proposal   → describe planned structure, wait for approval
@@ -195,6 +231,7 @@ QUALITY CRITERIA: [how you'll know it's done]
 ## 5. Token-Aware Prompting
 
 ### Global RULESET block (prepend to every design-system prompt)
+
 ```
 GLOBAL RULESET
 - SOURCE: Penpot MCP only
@@ -216,11 +253,13 @@ STYLE
 ```
 
 ### Token hierarchy
+
 ```
 Tier 1 (Global):    color.base.neutral.100, spacing.base.8
 Tier 2 (Semantic):  color.bg.default, color.text.primary
 Tier 3 (Component): color.button.primary.bg
 ```
+
 Reference tokens can be other tokens: `'{color.base.neutral.100}'` — use curly brace syntax.
 
 ---
@@ -228,7 +267,8 @@ Reference tokens can be other tokens: `'{color.base.neutral.100}'` — use curly
 ## 6. Workflow Recipes
 
 Read the relevant reference before starting:
-- **Full API, tokens, page management, storage, visual effects** → `references/penpot-api-patterns.md` *(mandatory before any `execute_code` calls)*
+
+- **Full API, tokens, page management, storage, visual effects** → `references/penpot-api-patterns.md` _(mandatory before any `execute_code` calls)_
 - **Design system creation/audit** → `references/design-system-workflows.md`
 - **Design-to-code generation** → `references/design-to-code-workflows.md`
 - **Prototyping: flows, interactions, animations** → `references/prototyping-workflows.md`
@@ -236,6 +276,7 @@ Read the relevant reference before starting:
 ### Quick reference: Common task prompts
 
 **Design system from scratch:**
+
 ```
 "Read all existing pages, colors, typographies, and token sets in this file."
 
@@ -251,6 +292,7 @@ Use ensureTypography. Check installed font variants first."
 ```
 
 **Multi-page design system:**
+
 ```
 "Create pages: [Page1], [Page2], [Page3] — all in one call (list all pages to create).
 Then report the current page list before doing anything else."
@@ -262,6 +304,7 @@ Max 8 shapes per call. Pause after."
 ```
 
 **Prototyping tasks:**
+
 ```
 "List all boards on this page and their existing interactions."
 
@@ -273,6 +316,7 @@ Max 8 shapes per call. Pause after."
 ```
 
 **Visual effects:**
+
 ```
 "Apply a backdrop blur effect to the [BoardName] overlay:
 [N]px layer-blur, [N]px borderRadius, semi-transparent surface fill,
@@ -286,6 +330,7 @@ and a drop shadow. Describe the values you'll use before applying."
 ## 7. Design File Best Practices
 
 ### File & page structure
+
 - Choose one page organisation strategy:
   - **Domain-based**: e.g. `Foundations`, `Mobile`, `Desktop`
   - **Atomic-level**: e.g. `Tokens`, `Primitives`, `Components`, `Patterns`
@@ -293,35 +338,42 @@ and a drop shadow. Describe the values you'll use before applying."
 - Every board has a clear purpose and visual entry point
 
 ### Layer naming
+
 - Function-based: `background`, `icon-close`, `label-primary` ✅
 - Not appearance-based: `rectangle-23`, `blue-box` ❌
 - Hierarchy with `/`: `component/card/default`, `overlay/confirm-delete`
 
 ### Components
+
 - Naming: `mobile/card/default`, `mobile/nav-bar`
 - Register from source shapes via `createComponent([shapes])`
 - Clone source shape first if it's already placed on a page
 
 ### Spacing & layout
+
 - Base unit: 8px. All margins/paddings derived from it.
 - No invisible rectangles for spacing — use Flex/Grid layout
 
 ### Visual effects & glassmorphism
+
 - Glass recipe: `blurs: [{ type: 'layer-blur', value: 20 }]` + `borderRadius: 20` + shadow
 - Shadow color: `{ color: '#hex', opacity: 0.06 }` (not r/g/b/a)
 - Ghost border only when accessibility explicitly requires it
 
 ### Prototyping
+
 - Flow entry boards: prefix `/flows/[journey]-start`
 - Overlay boards: prefix `overlay/`
 - Create flows via `page.createFlow('name', entryBoard)` or Prototype panel
 
 ### Accessibility
+
 - WCAG AA contrast minimum for all text
 - 44px min touch target (iOS) / 48dp (Android)
 - Never use color alone to communicate status
 
 ### Handoff readiness
+
 - Component/variable names developer-readable
 - No duplicates — single source of truth
 
@@ -340,36 +392,36 @@ and a drop shadow. Describe the values you'll use before applying."
 
 **MCP/infrastructure:**
 
-| Gotcha | Mitigation |
-|--------|-----------|
-| MCP acts on focused page only | Confirm page focus before each write batch |
-| Write ops immediate — no undo via MCP | Plan + describe before applying |
-| Large batches time out silently | Max ~10 ops per call; verify after each |
-| Page switch is async | Never switch page and write in same call |
+| Gotcha                                  | Mitigation                                         |
+| --------------------------------------- | -------------------------------------------------- |
+| MCP acts on focused page only           | Confirm page focus before each write batch         |
+| Write ops immediate — no undo via MCP   | Plan + describe before applying                    |
+| Large batches time out silently         | Max ~10 ops per call; verify after each            |
+| Page switch is async                    | Never switch page and write in same call           |
 | `export_shape` may fail with HTTP error | Verify structurally via API; export is best-effort |
-| Remote MCP can't read local file system | Use local MCP for `import_image` |
-| Only one active MCP tab | Close other Penpot tabs before running agents |
-| MCP key shown only once | Copy immediately; regenerate if lost |
-| Expired key blocks all connections | Regenerate in Integrations; update all configs |
-| Chromium ≥142 blocks localhost | Use Firefox, or allow local network explicitly |
+| Remote MCP can't read local file system | Use local MCP for `import_image`                   |
+| Only one active MCP tab                 | Close other Penpot tabs before running agents      |
+| MCP key shown only once                 | Copy immediately; regenerate if lost               |
+| Expired key blocks all connections      | Regenerate in Integrations; update all configs     |
+| Chromium ≥142 blocks localhost          | Use Firefox, or allow local network explicitly     |
 
 **Penpot plugin API (full detail → `references/penpot-api-patterns.md`):**
 
-| Gotcha | Mitigation |
-|--------|-----------|
-| `shape.width` / `shape.height` READ-ONLY | Use `shape.resize(w, h)` |
-| `shape.x` / `shape.y` READ-ONLY for parented shapes | Use `penpotUtils.setParentXY(shape, x, y)` |
-| `shape.x` / `shape.y` for root-level boards | ✅ Direct assignment works |
-| `appendChild` ignores z-order | Use `insertChild(index, shape)` |
-| Flex children reversed for column dirs | Last inserted = top visually |
-| Text clips after `resize()` | Always reset `growType` after every `text.resize()` |
-| Font weight rejection | Only use weights explicitly installed for the font family |
-| Library `fontSize` must be string | `"16"` not `16`; library typographies use `fontFamilies` not `fontFamily` |
-| `LibraryColor.color` for hex | `.color = '#hex'` not `.fillColor` |
-| `shape.blurs` is an array | `shape.blurs = [{ type: 'layer-blur', value: 20 }]` |
-| Shadow color format | `{ color: '#hex', opacity: 0.15 }` not `{r,g,b,a}` |
-| Typography `fontId` stays stale | Known API limitation; rendered layers use correct ID |
-| `storage` resets on server restart | Always use `|| fallback` when reading |
-| `Page.findShapes()` takes criteria object | `page.findShapes({ type: 'board' })` not a predicate |
-| `createComponent` wraps an array | `createComponent([shape])` not `createComponent(shape)` |
-
+| Gotcha                                              | Mitigation                                                                |
+| --------------------------------------------------- | ------------------------------------------------------------------------- |
+| `shape.width` / `shape.height` READ-ONLY            | Use `shape.resize(w, h)`                                                  |
+| `shape.x` / `shape.y` READ-ONLY for parented shapes | Use `penpotUtils.setParentXY(shape, x, y)`                                |
+| `shape.x` / `shape.y` for root-level boards         | ✅ Direct assignment works                                                |
+| `appendChild` ignores z-order                       | Use `insertChild(index, shape)`                                           |
+| Flex children reversed for column dirs              | Last inserted = top visually                                              |
+| `penpot.createText(...)` may return null            | Guard before resize/style calls; return a clear error if unavailable      |
+| Text clips after `resize()`                         | Always reset `growType` after every `text.resize()`                       |
+| Font weight rejection                               | Only use weights explicitly installed for the font family                 |
+| Library `fontSize` must be string                   | `"16"` not `16`; library typographies use `fontFamilies` not `fontFamily` |
+| `LibraryColor.color` for hex                        | `.color = '#hex'` not `.fillColor`                                        |
+| `shape.blurs` is an array                           | `shape.blurs = [{ type: 'layer-blur', value: 20 }]`                       |
+| Shadow color format                                 | `{ color: '#hex', opacity: 0.15 }` not `{r,g,b,a}`                        |
+| Typography `fontId` stays stale                     | Known API limitation; rendered layers use correct ID                      |
+| `storage` resets on server restart                  | Always use a fallback value when reading                                  |
+| `Page.findShapes()` takes criteria object           | `page.findShapes({ type: 'board' })` not a predicate                      |
+| `createComponent` wraps an array                    | `createComponent([shape])` not `createComponent(shape)`                   |

--- a/penpot-mcp/references/design-system-workflows.md
+++ b/penpot-mcp/references/design-system-workflows.md
@@ -243,4 +243,3 @@ For the currently focused file:
 
 Output as JSON with counts and a 'sync_health' score (0-100)."
 ```
-

--- a/penpot-mcp/references/design-to-code-workflows.md
+++ b/penpot-mcp/references/design-to-code-workflows.md
@@ -357,4 +357,3 @@ Analyze the pasted CSS and flag any:
 - Hardcoded spacing values
 - Incorrect variable names (typos or old names)"
 ```
-

--- a/penpot-mcp/references/penpot-api-patterns.md
+++ b/penpot-mcp/references/penpot-api-patterns.md
@@ -27,7 +27,7 @@ Concrete JavaScript for `execute_code`, critical gotchas, font/typography constr
 
 ## 1. Always Check Connection First
 
-```
+```text
 Call: mcp__penpot__penpot_api_info  (or high_level_overview)
 ```
 
@@ -170,6 +170,7 @@ shape.setSharedPluginData("design-system", "token", "color.primary.500");
 | `shape.x` / `shape.y` for parented shapes   | ❌ READ-ONLY              | `penpotUtils.setParentXY(shape, x, y)`             |
 | `shape.x` / `shape.y` for root-level shapes | ✅ Works                  | Direct assignment OK for top-level boards          |
 | Z-ordering via `appendChild`                | ❌ Ignores order          | `insertChild(index, shape)`                        |
+| `penpot.createText(...)`                    | ⚠️ Nullable               | Check result before resize/style calls             |
 | Text clips after `resize()`                 | ⚠️ Reset required         | Set `growType` after every `text.resize()`         |
 | Flex children order                         | ⚠️ Reversed               | For column: last inserted = visually top           |
 | Page switch + write in same call            | ❌ Writes to wrong page   | Two calls: switch page, then write                 |
@@ -192,6 +193,8 @@ container.insertChild(2, header); // top ← counter-intuitive
 
 ```javascript
 const label = penpot.createText("Button Label");
+if (!label) return { error: "Text creation failed" };
+
 label.resize(120, 0);
 label.growType = "auto-height"; // MUST follow every resize
 label.fontSize = "14"; // string
@@ -659,7 +662,7 @@ The `storage` object persists across all `execute_code` calls within a single MC
 
 ```javascript
 // ── Call 1: store design system data ──
-const DS = { colors: { primary: '#RRGGBB' }, typography: [] };
+const DS = { colors: { primary: "#RRGGBB" }, typography: [] };
 storage.designSystem = DS;
 return { stored: true, colorCount: Object.keys(DS.colors).length };
 ```
@@ -671,14 +674,17 @@ const DS = storage.designSystem || fallback; // fallback if session reset
 const C = DS.colors;
 
 // Pattern for processing queues
-storage.shapesToProcess = allShapes.map(s => s.id);
+storage.shapesToProcess = allShapes.map((s) => s.id);
 storage.processed = [];
 
 // Later call:
 const id = storage.shapesToProcess.shift();
 const shape = penpotUtils.findShapeById(id);
 storage.processed.push(id);
-return { remaining: storage.shapesToProcess.length, done: storage.processed.length };
+return {
+  remaining: storage.shapesToProcess.length,
+  done: storage.processed.length,
+};
 ```
 
 > **Note:** `storage` is session-scoped — it resets when the MCP server is restarted. Always use `|| fallback` when reading from storage.
@@ -1050,7 +1056,7 @@ return {
 
 ### Mobile (375×812)
 
-```
+```text
 ┌─────────────────────────────┐
 │ Status Bar          (44px)  │
 ├─────────────────────────────┤
@@ -1070,7 +1076,7 @@ return {
 
 ### Desktop Dashboard (1440×900)
 
-```
+```text
 ┌──────┬──────────────────────────────────┐
 │Sidebar│ Header                  (64px)  │
 │ 240px ├──────────────────────────────────┤
@@ -1137,13 +1143,13 @@ platforms.forEach(({ name, w, h }) => {
 
 ### Border radius
 
-| Token         | Value  | Usage          |
-| ------------- | ------ | -------------- |
-| `radius-sm`   | 4px    | Inputs, tags   |
-| `radius-md`   | 8px    | Cards          |
-| `radius-lg`   | 16px   | Panels         |
-| `radius-full` | 9999px | Pills, avatars |
-| `radius-overlay` | 20px | Overlays, glass panels |
+| Token            | Value  | Usage                  |
+| ---------------- | ------ | ---------------------- |
+| `radius-sm`      | 4px    | Inputs, tags           |
+| `radius-md`      | 8px    | Cards                  |
+| `radius-lg`      | 16px   | Panels                 |
+| `radius-full`    | 9999px | Pills, avatars         |
+| `radius-overlay` | 20px   | Overlays, glass panels |
 
 ---
 
@@ -1188,4 +1194,3 @@ platforms.forEach(({ name, w, h }) => {
 - [ ] All layers semantically named
 - [ ] No hard-coded colors or spacing
 - [ ] Interactions wired and verified
-

--- a/penpot-mcp/references/prototyping-workflows.md
+++ b/penpot-mcp/references/prototyping-workflows.md
@@ -355,4 +355,3 @@ return { created: screens.length };
 - `ease-out` → overlay appears quickly, feels responsive
 - `ease-in` → element leaves quickly; use for exit animations
 - `linear` → only for loading bars or mechanical animations
-

--- a/scripts/validate-package.mjs
+++ b/scripts/validate-package.mjs
@@ -1,0 +1,286 @@
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { dirname, join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repositoryRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+const failures = [];
+
+const requiredReferenceFiles = [
+  "penpot-mcp/references/penpot-api-patterns.md",
+  "penpot-mcp/references/design-system-workflows.md",
+  "penpot-mcp/references/design-to-code-workflows.md",
+  "penpot-mcp/references/prototyping-workflows.md",
+];
+
+const skippedDirectories = new Set([".git", "node_modules"]);
+const textFileExtensions = new Set([".json", ".md", ".mjs", ".yml", ".yaml"]);
+
+function fail(message) {
+  failures.push(message);
+}
+
+function repositoryPath(filePath) {
+  return join(repositoryRoot, filePath);
+}
+
+function readRepositoryFile(filePath) {
+  return readFileSync(repositoryPath(filePath), "utf8");
+}
+
+function stripQuotes(value) {
+  return value.replace(/^['"]|['"]$/g, "");
+}
+
+function readFrontmatterValue(frontmatter, key) {
+  const lines = frontmatter.split(/\r?\n/);
+  const keyPattern = new RegExp(`^${key}:\\s*(.*)$`);
+
+  for (let lineIndex = 0; lineIndex < lines.length; lineIndex += 1) {
+    const match = lines[lineIndex].match(keyPattern);
+    if (!match) continue;
+
+    const value = match[1].trim();
+    if (value !== ">" && value !== "|") {
+      return stripQuotes(value.trim());
+    }
+
+    const foldedLines = [];
+    for (
+      let nextIndex = lineIndex + 1;
+      nextIndex < lines.length;
+      nextIndex += 1
+    ) {
+      const nextLine = lines[nextIndex];
+      if (/^[A-Za-z0-9_-]+:\s*/.test(nextLine)) break;
+      if (nextLine.trim().length > 0) foldedLines.push(nextLine.trim());
+    }
+
+    return foldedLines.join(" ").trim();
+  }
+
+  return "";
+}
+
+function validatePackageJson() {
+  let packageJson;
+  try {
+    packageJson = JSON.parse(readRepositoryFile("package.json"));
+  } catch (error) {
+    fail(`package.json is not valid JSON: ${error.message}`);
+    return null;
+  }
+
+  if (packageJson.name !== "penpot-mcp") {
+    fail("package.json name must be penpot-mcp");
+  }
+
+  if (
+    !/^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/.test(packageJson.version || "")
+  ) {
+    fail("package.json version must be valid semver");
+  }
+
+  if (!packageJson.description || typeof packageJson.description !== "string") {
+    fail("package.json description is required");
+  }
+
+  if (packageJson.license !== "MIT") {
+    fail("package.json license must be MIT");
+  }
+
+  return packageJson;
+}
+
+function validateReadmeVersionBadge(packageJson) {
+  const readme = readRepositoryFile("README.md");
+  const dynamicBadgePattern =
+    /img\.shields\.io\/github\/package-json\/v\/ar27111994\/penpot-mcp\b/;
+  const hardcodedBadgeMatch = readme.match(
+    /img\.shields\.io\/badge\/version-([0-9A-Za-z.+-]+)-blue\.svg/,
+  );
+
+  if (dynamicBadgePattern.test(readme)) return;
+
+  if (!hardcodedBadgeMatch) {
+    fail(
+      "README.md must include a version badge backed by package.json or matching package.json version",
+    );
+    return;
+  }
+
+  if (hardcodedBadgeMatch[1] !== packageJson.version) {
+    fail(
+      `README.md version badge ${hardcodedBadgeMatch[1]} does not match package.json ${packageJson.version}`,
+    );
+  }
+}
+
+function validateSkillFrontmatter() {
+  const skill = readRepositoryFile("penpot-mcp/SKILL.md");
+  const frontmatterMatch = skill.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+
+  if (!frontmatterMatch) {
+    fail("penpot-mcp/SKILL.md must start with YAML frontmatter");
+    return;
+  }
+
+  const frontmatter = frontmatterMatch[1];
+  const name = readFrontmatterValue(frontmatter, "name");
+  const description = readFrontmatterValue(frontmatter, "description");
+
+  if (name !== "penpot-mcp") {
+    fail("penpot-mcp/SKILL.md frontmatter name must be penpot-mcp");
+  }
+
+  if (!description) {
+    fail("penpot-mcp/SKILL.md frontmatter description is required");
+  }
+}
+
+function validateRequiredReferences() {
+  for (const filePath of requiredReferenceFiles) {
+    if (!existsSync(repositoryPath(filePath))) {
+      fail(`Required reference file is missing: ${filePath}`);
+    }
+  }
+}
+
+function splitMarkdownTableRow(line) {
+  const cells = [];
+  let currentCell = "";
+  let codeTickCount = 0;
+
+  for (let index = 0; index < line.length; index += 1) {
+    const character = line[index];
+
+    if (character === "\\" && index + 1 < line.length) {
+      currentCell += character + line[index + 1];
+      index += 1;
+      continue;
+    }
+
+    if (character === "`") {
+      let nextIndex = index;
+      while (line[nextIndex] === "`") nextIndex += 1;
+      const tickRun = nextIndex - index;
+      currentCell += "`".repeat(tickRun);
+
+      if (codeTickCount === 0) {
+        codeTickCount = tickRun;
+      } else if (codeTickCount === tickRun) {
+        codeTickCount = 0;
+      }
+
+      index = nextIndex - 1;
+      continue;
+    }
+
+    if (character === "|" && codeTickCount === 0) {
+      cells.push(currentCell.trim());
+      currentCell = "";
+      continue;
+    }
+
+    currentCell += character;
+  }
+
+  cells.push(currentCell.trim());
+
+  if (line.trimStart().startsWith("|")) cells.shift();
+  if (line.trimEnd().endsWith("|")) cells.pop();
+
+  return cells;
+}
+
+function validateMarkdownTableBlock(filePath, rows) {
+  if (rows.length < 2) return;
+
+  const expectedColumnCount = splitMarkdownTableRow(rows[0].line).length;
+  for (const row of rows) {
+    const columnCount = splitMarkdownTableRow(row.line).length;
+    if (columnCount !== expectedColumnCount) {
+      fail(
+        `${filePath}:${row.lineNumber} has ${columnCount} table columns; expected ${expectedColumnCount}`,
+      );
+    }
+  }
+}
+
+function validateMarkdownTables(filePath) {
+  const lines = readRepositoryFile(filePath).split(/\r?\n/);
+  let inFence = false;
+  let tableRows = [];
+
+  function flushTableRows() {
+    validateMarkdownTableBlock(filePath, tableRows);
+    tableRows = [];
+  }
+
+  lines.forEach((line, index) => {
+    if (/^\s*(```|~~~)/.test(line)) {
+      flushTableRows();
+      inFence = !inFence;
+      return;
+    }
+
+    if (!inFence && line.trim().startsWith("|") && line.includes("|")) {
+      tableRows.push({ line, lineNumber: index + 1 });
+      return;
+    }
+
+    flushTableRows();
+  });
+
+  flushTableRows();
+}
+
+function collectTextFiles(directoryPath = repositoryRoot) {
+  const files = [];
+
+  for (const entry of readdirSync(directoryPath)) {
+    if (skippedDirectories.has(entry)) continue;
+
+    const entryPath = join(directoryPath, entry);
+    const stats = statSync(entryPath);
+
+    if (stats.isDirectory()) {
+      files.push(...collectTextFiles(entryPath));
+      continue;
+    }
+
+    const extension = entry.slice(entry.lastIndexOf("."));
+    if (textFileExtensions.has(extension)) {
+      files.push(relative(repositoryRoot, entryPath).replace(/\\/g, "/"));
+    }
+  }
+
+  return files;
+}
+
+function validateTrailingWhitespace(filePath) {
+  const lines = readRepositoryFile(filePath).split(/\r?\n/);
+
+  lines.forEach((line, index) => {
+    if (/[ \t]+$/.test(line)) {
+      fail(`${filePath}:${index + 1} has trailing whitespace`);
+    }
+  });
+}
+
+const packageJson = validatePackageJson();
+if (packageJson) validateReadmeVersionBadge(packageJson);
+validateSkillFrontmatter();
+validateRequiredReferences();
+
+for (const filePath of collectTextFiles()) {
+  validateTrailingWhitespace(filePath);
+  if (filePath.endsWith(".md")) validateMarkdownTables(filePath);
+}
+
+if (failures.length > 0) {
+  console.error("Validation failed:");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log("Package validation passed");

--- a/scripts/validate-package.mjs
+++ b/scripts/validate-package.mjs
@@ -15,22 +15,27 @@ const requiredReferenceFiles = [
 const skippedDirectories = new Set([".git", "node_modules"]);
 const textFileExtensions = new Set([".json", ".md", ".mjs", ".yml", ".yaml"]);
 
+/** Records a validation failure without stopping later checks. */
 function fail(message) {
   failures.push(message);
 }
 
+/** Resolves a repository-relative path to an absolute path. */
 function repositoryPath(filePath) {
   return join(repositoryRoot, filePath);
 }
 
+/** Reads a UTF-8 file from a repository-relative path. */
 function readRepositoryFile(filePath) {
   return readFileSync(repositoryPath(filePath), "utf8");
 }
 
+/** Removes one pair of surrounding quotes from a YAML scalar value. */
 function stripQuotes(value) {
   return value.replace(/^['"]|['"]$/g, "");
 }
 
+/** Extracts a simple or folded scalar from the SKILL.md frontmatter. */
 function readFrontmatterValue(frontmatter, key) {
   const lines = frontmatter.split(/\r?\n/);
   const keyPattern = new RegExp(`^${key}:\\s*(.*)$`);
@@ -61,6 +66,7 @@ function readFrontmatterValue(frontmatter, key) {
   return "";
 }
 
+/** Validates root package metadata needed for publishing and discovery. */
 function validatePackageJson() {
   let packageJson;
   try {
@@ -91,6 +97,7 @@ function validatePackageJson() {
   return packageJson;
 }
 
+/** Ensures the README version badge cannot drift from package.json. */
 function validateReadmeVersionBadge(packageJson) {
   const readme = readRepositoryFile("README.md");
   const dynamicBadgePattern =
@@ -115,6 +122,7 @@ function validateReadmeVersionBadge(packageJson) {
   }
 }
 
+/** Validates the skill discovery frontmatter required by agent clients. */
 function validateSkillFrontmatter() {
   const skill = readRepositoryFile("penpot-mcp/SKILL.md");
   const frontmatterMatch = skill.match(/^---\r?\n([\s\S]*?)\r?\n---/);
@@ -137,6 +145,7 @@ function validateSkillFrontmatter() {
   }
 }
 
+/** Ensures all reference files advertised by the package exist. */
 function validateRequiredReferences() {
   for (const filePath of requiredReferenceFiles) {
     if (!existsSync(repositoryPath(filePath))) {
@@ -145,6 +154,7 @@ function validateRequiredReferences() {
   }
 }
 
+/** Splits a Markdown table row while ignoring pipes inside inline code. */
 function splitMarkdownTableRow(line) {
   const cells = [];
   let currentCell = "";
@@ -192,6 +202,7 @@ function splitMarkdownTableRow(line) {
   return cells;
 }
 
+/** Validates one contiguous Markdown table block for stable column counts. */
 function validateMarkdownTableBlock(filePath, rows) {
   if (rows.length < 2) return;
 
@@ -206,11 +217,13 @@ function validateMarkdownTableBlock(filePath, rows) {
   }
 }
 
+/** Validates Markdown tables while ignoring fenced code blocks. */
 function validateMarkdownTables(filePath) {
   const lines = readRepositoryFile(filePath).split(/\r?\n/);
   let activeFence = null;
   let tableRows = [];
 
+  /** Flushes the current candidate table block into the table validator. */
   function flushTableRows() {
     validateMarkdownTableBlock(filePath, tableRows);
     tableRows = [];
@@ -250,6 +263,7 @@ function validateMarkdownTables(filePath) {
   flushTableRows();
 }
 
+/** Collects repository text files that should be covered by validation. */
 function collectTextFiles(directoryPath = repositoryRoot) {
   const files = [];
 
@@ -273,6 +287,7 @@ function collectTextFiles(directoryPath = repositoryRoot) {
   return files;
 }
 
+/** Fails when a text file contains trailing spaces or tabs. */
 function validateTrailingWhitespace(filePath) {
   const lines = readRepositoryFile(filePath).split(/\r?\n/);
 

--- a/scripts/validate-package.mjs
+++ b/scripts/validate-package.mjs
@@ -208,7 +208,7 @@ function validateMarkdownTableBlock(filePath, rows) {
 
 function validateMarkdownTables(filePath) {
   const lines = readRepositoryFile(filePath).split(/\r?\n/);
-  let inFence = false;
+  let activeFence = null;
   let tableRows = [];
 
   function flushTableRows() {
@@ -217,13 +217,29 @@ function validateMarkdownTables(filePath) {
   }
 
   lines.forEach((line, index) => {
-    if (/^\s*(```|~~~)/.test(line)) {
-      flushTableRows();
-      inFence = !inFence;
+    const fenceMatch = line.match(/^\s*(`{3,}|~{3,})/);
+
+    if (fenceMatch) {
+      const fenceMarker = fenceMatch[1];
+      const fenceCharacter = fenceMarker[0];
+
+      if (!activeFence) {
+        flushTableRows();
+        activeFence = { character: fenceCharacter, length: fenceMarker.length };
+        return;
+      }
+
+      if (
+        activeFence.character === fenceCharacter &&
+        fenceMarker.length >= activeFence.length
+      ) {
+        activeFence = null;
+      }
+
       return;
     }
 
-    if (!inFence && line.trim().startsWith("|") && line.includes("|")) {
+    if (!activeFence && line.trim().startsWith("|") && line.includes("|")) {
       tableRows.push({ line, lineNumber: index + 1 });
       return;
     }


### PR DESCRIPTION
## Summary
- Add package validation for skill metadata, README/package version badge sync, required reference files, trailing whitespace, and Markdown table consistency
- Add ESLint and scoped Prettier checks for tooling files, backed by package-lock.json and CI
- Add a GitHub Actions validation workflow pinned to immutable action commit SHAs
- Fix publish-readiness documentation issues, including the malformed gotchas table and README version badge sync

## Validation
- `npm run format:check`
- `npm run lint`
- `npm run validate`
- `npm run check:whitespace`
- `npm audit --audit-level=moderate`

## Notes
- Adds devDependencies and a lockfile for ESLint/Prettier developer tooling only.
- No runtime dependencies, Jest, TypeScript, or release automation added.
- GitHub Actions are pinned by commit SHA with source tag comments for maintainability.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a dependency-free publish-readiness validation script (`scripts/validate-package.mjs`) and a GitHub Actions workflow to run it on every push and PR. It also fixes documentation issues in `penpot-mcp/SKILL.md` and reference files, updates the README version badge to a dynamic package-json-backed URL, and adds the supporting toolchain (`eslint`, `prettier`, lockfile, `.gitignore`, `.prettierignore`).

- **Validation script** (`scripts/validate-package.mjs`): checks `package.json` metadata, README badge/version sync, SKILL.md frontmatter, required reference files, trailing whitespace, and Markdown table column consistency. Fence-block tracking correctly uses character + length matching to avoid the desync issue from the prior review.
- **CI workflow** (`.github/workflows/validate.yml`): lint → format check → validate, with actions pinned to verified immutable SHAs (`actions/checkout@v6.0.2`, `actions/setup-node@v6.4.0`) and `persist-credentials: false`.
- **Docs**: SKILL.md connection setup, gotcha tables, and reference files restructured; README badge switched from a static tag badge to the dynamic `img.shields.io/github/package-json/v` URL now enforced by the validate script.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the only finding is a narrow regex edge case in the frontmatter parser that does not affect current content.

The validation script and CI workflow are well-structured and add genuine quality gates. The one finding — a too-broad `\s*` in the folded-scalar break regex that could silently truncate a SKILL.md description if it ever contains an unindented URL — does not affect the current file content (all description lines are indented) but is a latent correctness issue for future edits.

scripts/validate-package.mjs — specifically the `readFrontmatterValue` folded-scalar termination regex at line 59.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| scripts/validate-package.mjs | New validation script covering package.json metadata, README badge sync, SKILL.md frontmatter, required reference files, trailing whitespace, and Markdown table column consistency. Fence-block tracking is correctly implemented with character+length matching. Minor: the folded-scalar break regex uses `\s*` (matches zero whitespace) which could prematurely terminate parsing if a description line starts with a URL scheme like `http:`. |
| .github/workflows/validate.yml | New CI workflow: checkout, Node 20.19.0, lint, format check, and validate. Actions pinned by verified SHA (checkout v6.0.2 and setup-node v6.4.0 confirmed real releases). `persist-credentials: false` is a nice security touch. |
| package.json | Version bumped to 1.4.0; lint, format:check, validate, and check:whitespace scripts added; eslint and prettier added as devDependencies. |
| eslint.config.mjs | New flat ESLint config scoped to eslint.config.mjs and scripts/**/*.mjs with sensible rules (eqeqeq, no-undef, no-unused-vars, etc.) and minimal node globals. |
| README.md | Version badge switched from static GitHub tag badge to dynamic package-json badge (now matches the validate script's preferred path); line count annotation removed from SKILL.md entry; trailing newline removed. |
| penpot-mcp/SKILL.md | Connection setup, tool descriptions, and gotcha tables restructured and fixed; YAML frontmatter valid with required name and description fields. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[npm run validate] --> B[validatePackageJson]
    B --> C{Valid JSON & fields?}
    C -- No --> F1[fail: package.json error]
    C -- Yes --> D[validateReadmeVersionBadge]
    D --> E{Dynamic badge OR matching hardcoded badge?}
    E -- No --> F2[fail: badge mismatch]
    E -- Yes --> G[validateSkillFrontmatter]
    G --> H{name=penpot-mcp & description present?}
    H -- No --> F3[fail: frontmatter error]
    H -- Yes --> I[validateRequiredReferences]
    I --> J{All 4 ref files exist?}
    J -- No --> F4[fail: missing file]
    J -- Yes --> K[collectTextFiles]
    K --> L[For each .json/.md/.mjs/.yml/.yaml]
    L --> M[validateTrailingWhitespace]
    M --> N{Trailing spaces/tabs?}
    N -- Yes --> F5[fail: whitespace]
    N -- No --> O{.md file?}
    O -- Yes --> P[validateMarkdownTables]
    P --> Q{Consistent column counts?}
    Q -- Yes --> R{More files?}
    Q -- No --> F6[fail: column mismatch]
    O -- No --> R
    R -- Yes --> L
    R -- No --> S{Any failures?}
    S -- Yes --> T[Exit 1]
    S -- No --> U[Package validation passed]
```

<sub>Reviews (4): Last reviewed commit: ["Address final validation review feedback"](https://github.com/ar27111994/penpot-mcp/commit/9d086f1d9f736996fc63be5ff84153df45df8732) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34128530)</sub>

<!-- /greptile_comment -->