### PR TITLE
docs: add community plugin guardrails

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,41 @@
+name: Bug report
+description: Report incorrect, unsafe, or broken skill guidance
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping improve `penpot-mcp`. Do not include MCP keys, private Penpot URLs, or proprietary file contents.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What is incorrect, unsafe, outdated, or broken?
+      placeholder: Describe the issue and where it appears.
+    validations:
+      required: true
+  - type: input
+    id: location
+    attributes:
+      label: Location
+      description: File, section, line, or URL if known.
+      placeholder: penpot-mcp/SKILL.md, README.md, reference section, etc.
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected guidance
+      description: What should the skill say or do instead?
+    validations:
+      required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence / source
+      description: Link official docs, MCP behavior, or a minimal generic reproduction if possible.
+  - type: checkboxes
+    id: safety
+    attributes:
+      label: Safety confirmation
+      options:
+        - label: I did not include secrets, MCP keys, private file contents, or proprietary project details.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Penpot MCP Skill community thread
+    url: https://community.penpot.app/t/penpot-mcp-skill/10599
+    about: Discuss usage, feedback, and community updates.
+  - name: Official Penpot MCP documentation
+    url: https://help.penpot.app/mcp/
+    about: Check official setup and MCP server documentation.

--- a/.github/ISSUE_TEMPLATE/workflow_recipe.yml
+++ b/.github/ISSUE_TEMPLATE/workflow_recipe.yml
@@ -1,0 +1,42 @@
+name: Workflow recipe request
+description: Suggest a new Penpot MCP workflow, prompt pattern, or reference example
+labels: [enhancement, documentation]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Suggest generic, community-useful workflows only. Avoid private product details or unsupported Penpot behavior.
+  - type: textarea
+    id: workflow
+    attributes:
+      label: Workflow
+      description: What should the skill help agents do?
+      placeholder: e.g. audit interaction coverage, normalize design tokens, prepare handoff assets.
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: User scenario
+      description: When would an agent use this workflow?
+    validations:
+      required: true
+  - type: textarea
+    id: constraints
+    attributes:
+      label: Constraints and safety notes
+      description: Include relevant batching, verification, accessibility, or plugin/API limitations.
+  - type: textarea
+    id: sources
+    attributes:
+      label: Sources or examples
+      description: Link official Penpot/MCP docs or provide generic examples.
+  - type: checkboxes
+    id: confirmations
+    attributes:
+      label: Confirmation
+      options:
+        - label: This request is generic and does not include private project data.
+          required: true
+        - label: This request does not depend on unsupported Penpot MCP behavior.
+          required: true

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,32 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "04:00"
+      timezone: Asia/Karachi
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: deps
+    groups:
+      npm-dev-dependencies:
+        dependency-type: development
+        patterns:
+          - "*"
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "04:30"
+      timezone: Asia/Karachi
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: ci
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,33 @@
+## Summary
+
+-
+
+## Type of change
+
+- [ ] Documentation / skill content
+- [ ] Reference workflow or example
+- [ ] Validation / packaging
+- [ ] Metadata / release prep
+- [ ] Other:
+
+## Penpot MCP safety checklist
+
+- [ ] I preserved inspect-first guidance (`penpot_api_info` / `high_level_overview`).
+- [ ] I preserved READ -> PLAN -> WRITE -> VERIFY guidance for modifications.
+- [ ] I kept write examples small and batched.
+- [ ] I avoided switching pages and writing in the same `execute_code` example.
+- [ ] I used structural verification instead of relying only on `export_shape`.
+- [ ] I avoided unsupported Penpot MCP/plugin behavior claims.
+- [ ] I kept examples generic and removed private/project-specific details.
+
+## Validation
+
+- [ ] `npm run validate`
+- [ ] `npm run format:check`
+- [ ] `npm run lint`
+- [ ] `npm run check:whitespace`
+- [ ] `npm pack --dry-run`
+
+If any gate was skipped or failed, explain why:
+
+## Notes for reviewers

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,34 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "32 3 * * 1"
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: CodeQL
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.31.1
+        with:
+          languages: javascript-typescript
+          queries: security-extended
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.31.1

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,9 @@
 node_modules/
+.openclaw/
+AGENTS.md
+HEARTBEAT.md
+IDENTITY.md
+SOUL.md
+TOOLS.md
+USER.md
+*.tgz

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,9 @@
+node_modules/
+.openclaw/
+AGENTS.md
+HEARTBEAT.md
+IDENTITY.md
+SOUL.md
+TOOLS.md
+USER.md
+*.tgz

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,59 @@
+# Contributing
+
+Thanks for improving `penpot-mcp`. This repository packages an AI-agent skill for Penpot MCP workflows; it is primarily Markdown documentation, examples, and validation scripts.
+
+## What to contribute
+
+Good contributions include:
+
+- Corrections to Penpot MCP setup or client configuration.
+- Safer or clearer `execute_code` examples.
+- New workflow recipes for design systems, prototyping, accessibility, handoff, or design-to-code.
+- Updates when the official Penpot MCP Server or Penpot Plugin API changes.
+- Packaging, validation, or documentation quality improvements.
+
+Please keep examples generic and community-useful. Do not add private project details, unsupported Penpot behavior, or promotional copy.
+
+## Core invariants
+
+When changing skill docs or examples, preserve these rules:
+
+- Inspect first with `penpot_api_info` or `high_level_overview`; only guide setup when connection checks fail.
+- Follow READ -> PLAN -> WRITE -> VERIFY for Penpot modifications.
+- Keep `execute_code` writes small, usually 5-10 shape operations per call.
+- Never switch pages and write in the same `execute_code` call.
+- Verify structurally through the Penpot API; treat `export_shape` as best-effort.
+- Use `resize()` for shape size, `penpotUtils.setParentXY()` for parented coordinates, and `insertChild()` for z-order.
+- Guard nullable `penpot.createText(...)` results and reset text `growType` after resize.
+- Query installed font variants before applying font weights.
+- Use deterministic, idempotent check-before-create patterns.
+- Do not assume MCP can enumerate, install, launch, or drive arbitrary community plugins.
+
+## Local workflow
+
+1. Create a focused branch from `main`.
+2. Make the smallest clear change.
+3. Keep `README.md`, `package.json`, `penpot-mcp/SKILL.md`, and references aligned when changing public scope or metadata.
+4. Run validation before opening a PR:
+
+```bash
+npm ci
+npm run validate
+npm run format:check
+npm run lint
+npm run check:whitespace
+npm pack --dry-run
+```
+
+If a gate cannot run, explain why in the PR.
+
+## Pull requests
+
+A good PR includes:
+
+- A short summary of what changed.
+- The reason for the change and any source documentation used.
+- Validation commands and results.
+- Notes about any risky, uncertain, or intentionally conservative guidance.
+
+For JavaScript snippets intended for `execute_code`, check them against `penpot-mcp/references/penpot-api-patterns.md` before submitting.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Works with any MCP-compatible client: **Claude Code**, **Cursor**, **VS Code / C
 
 - **Remote & local MCP setup** — up-to-date configs for all major MCP clients; Remote MCP recommended for most users
 - **All 5 MCP tools** — `execute_code`, `high_level_overview`, `penpot_api_info`, `export_shape`, `import_image`
-- **Penpot JS API patterns** — `penpotUtils` reference, read-only property gotchas, flex ordering quirks, board positioning, CSS export, plugin data API
+- **Penpot JS API patterns** — `penpotUtils` reference, read-only property gotchas, flex ordering quirks, board positioning, CSS export, plugin data API, community plugin boundaries
 - **Font & typography constraints** — installed variant detection, library vs. layer fontSize types, stale `fontId` limitation
 - **Write safety rules** — batch size limits (~10 ops/call), page-switch two-call pattern, structural verification over export
 - **Interactions & animations** — full `addInteraction` API, all triggers (`click`, `mouse-enter`, `mouse-leave`, `after-delay`), all actions (`navigate-to`, `open-overlay`, `toggle-overlay`, `close-overlay`, `previous-screen`, `open-url`), all animations (`Dissolve`, `Slide`, `Push`) with easing options

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![GitHub Stars](https://img.shields.io/github/stars/ar27111994/penpot-mcp?style=flat&logo=github)](https://github.com/ar27111994/penpot-mcp/stargazers)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+[![Validate](https://github.com/ar27111994/penpot-mcp/actions/workflows/validate.yml/badge.svg)](https://github.com/ar27111994/penpot-mcp/actions/workflows/validate.yml)
 [![Agent Skills](https://img.shields.io/badge/npx_skills_add-ar27111994%2Fpenpot--mcp-8B5CF6)](https://github.com/ar27111994/penpot-mcp)
 [![skills.sh](https://skills.sh/b/ar27111994/penpot-mcp)](https://skills.sh/ar27111994/penpot-mcp)
 [![Version](https://img.shields.io/github/package-json/v/ar27111994/penpot-mcp?label=version)](https://github.com/ar27111994/penpot-mcp)
@@ -74,7 +75,9 @@ Key differences:
 
 ## Contributing
 
-PRs welcome — especially for new workflow recipes, additional platform templates, or corrections as the Penpot MCP API evolves. See [Penpot community thread](https://community.penpot.app/t/penpot-mcp-skill/10599).
+PRs welcome — especially for new workflow recipes, additional platform templates, or corrections as the Penpot MCP API evolves. See [CONTRIBUTING.md](CONTRIBUTING.md) and the [Penpot community thread](https://community.penpot.app/t/penpot-mcp-skill/10599).
+
+Please report security issues according to [SECURITY.md](SECURITY.md).
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,33 @@
+# Security Policy
+
+## Supported versions
+
+This repository tracks the current public `main` branch and the latest packaged skill version. Security fixes should target `main` unless maintainers explicitly note otherwise.
+
+## Reporting a vulnerability
+
+Please report suspected vulnerabilities through GitHub Security Advisories when available for this repository. If advisories are unavailable, open a minimal GitHub issue that avoids sensitive details and ask for a private disclosure path.
+
+Do not post secrets, private MCP keys, Penpot file contents, workspace URLs, or exploit details in public issues.
+
+## Scope
+
+In scope:
+
+- Unsafe instructions that could cause agents to expose MCP keys or private file data.
+- Documentation that encourages unreviewed destructive writes to Penpot files.
+- Packaging mistakes that publish local workspace files, secrets, or generated artifacts.
+- Validation gaps that allow malformed skill metadata or dangerous examples.
+
+Out of scope:
+
+- Vulnerabilities in Penpot, the official Penpot MCP Server, MCP clients, or third-party community plugins. Report those to their respective maintainers.
+- Issues requiring access to private Penpot files unless a minimal reproducible example is provided.
+
+## Security expectations for contributors
+
+- Never commit real MCP keys, access tokens, cookies, private URLs, or customer/project data.
+- Keep examples generic and deterministic.
+- Treat Remote MCP URLs containing `userToken=` as secrets.
+- Prefer read-only inspection before write guidance.
+- Do not add instructions that browse, install, or run community plugins automatically unless a user explicitly asked for plugin discovery or installation.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "AI-agent skill for creating, auditing, and maintaining production-grade Penpot design projects, design systems, flows, interactions, animations, tokens, and visual effects via the official Penpot MCP Server.",
   "scripts": {
     "lint": "eslint \"scripts/**/*.mjs\" eslint.config.mjs",
-    "format:check": "prettier --check package.json package-lock.json eslint.config.mjs scripts/**/*.mjs .github/workflows/**/*.yml",
+    "format:check": "prettier --check package.json package-lock.json eslint.config.mjs scripts/**/*.mjs .github/workflows/**/*.yml --end-of-line auto",
     "validate": "node scripts/validate-package.mjs",
     "check:whitespace": "git diff --check -- .github README.md package.json penpot-mcp scripts && git diff --cached --check -- .github README.md package.json penpot-mcp scripts"
   },

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "AI-agent skill for creating, auditing, and maintaining production-grade Penpot design projects, design systems, flows, interactions, animations, tokens, and visual effects via the official Penpot MCP Server.",
   "scripts": {
     "lint": "eslint \"scripts/**/*.mjs\" eslint.config.mjs",
-    "format:check": "prettier --check package.json package-lock.json eslint.config.mjs scripts/**/*.mjs .github/workflows/**/*.yml --end-of-line auto",
+    "format:check": "prettier --check package.json package-lock.json eslint.config.mjs scripts/**/*.mjs .github/**/*.yml --end-of-line auto",
     "validate": "node scripts/validate-package.mjs",
     "check:whitespace": "git diff --check -- .github README.md package.json penpot-mcp scripts && git diff --cached --check -- .github README.md package.json penpot-mcp scripts"
   },

--- a/penpot-mcp/SKILL.md
+++ b/penpot-mcp/SKILL.md
@@ -34,6 +34,8 @@ Penpot Plugin (running inside the open design file)
 
 MCP **always acts on the currently focused page** in the active Penpot browser tab. Only one tab can own MCP at a time.
 
+MCP runs through the Penpot MCP plugin. It does **not** provide a documented way to enumerate, install, launch, or drive arbitrary installed community plugins. Coordinate with other plugins only when the user explicitly asks or when file-visible evidence makes a plugin relevant.
+
 ---
 
 ## 1. Connection Setup
@@ -128,6 +130,15 @@ npx -y mcp-remote http://localhost:4401/mcp --allow-http
 ### Check connection first (always)
 
 Before any setup steps, **call `penpot_api_info` or `high_level_overview` first**. If it succeeds, skip setup entirely.
+
+### Community plugin guardrails
+
+- Do not assume MCP can read the user's installed plugin list or invoke another plugin's UI/API.
+- Prefer MCP-native reads/writes for normal design, prototyping, token, and export tasks.
+- If a community plugin could materially help, first look for file-visible evidence: generated layers, library assets, comments, or namespaced shared plugin data.
+- If the user provides an installed-plugin inventory, treat it as user-provided context and select a plugin only when the task clearly maps to that plugin's stated capability.
+- Ask for user confirmation before using or relying on any community plugin. If it has its own UI, ask the user to run it manually, then re-inspect the file.
+- Never use a plugin marketplace/browser plugin such as **Plugins list** unless the user explicitly asks to browse, search, discover, or install plugins. Do not search/install plugins automatically for routine tasks.
 
 ### JavaScript API
 

--- a/penpot-mcp/references/penpot-api-patterns.md
+++ b/penpot-mcp/references/penpot-api-patterns.md
@@ -159,6 +159,19 @@ page.setPluginData("role", "foundations");
 shape.setSharedPluginData("design-system", "token", "color.primary.500");
 ```
 
+### Community plugin boundaries
+
+The Penpot MCP Server runs through the Penpot MCP plugin and exposes the Penpot Plugin API. Do not assume it can list installed community plugins, install plugins, launch another plugin, or call another plugin's private UI/API. The documented plugin API supports file content, libraries, comments, user data, and plugin/shared plugin data according to the active plugin's manifest permissions; it is not a general installed-plugin automation bus.
+
+Safe coordination pattern:
+
+1. Use MCP to inspect the file first.
+2. If a task appears to need a community plugin, check only for file-visible evidence such as generated layers, library assets, comments, or namespaced shared plugin data.
+3. If the user provides an installed-plugin inventory, treat it as user-provided context and choose a plugin only when the task clearly maps to that plugin's stated capability.
+4. If the plugin must run, ask the user to confirm the exact installed plugin and whether they want it used.
+5. Ask the user to run that plugin manually when it requires its own UI or permissions, then re-inspect the file with MCP.
+6. Never browse, search, or install plugins from an agent loop unless the user explicitly requested plugin discovery or installation.
+
 ---
 
 ## 3. CRITICAL API Gotchas
@@ -221,9 +234,9 @@ for (let i = 0; i < shapes.length; i += 5) {
 // List all pages (returns {id, name}[] — lightweight)
 const pages = penpotUtils.getPages(); // [{id, name}]
 
-// Get Page object by name (full Page API)
-const page = penpotUtils.getPageByName("Mobile"); // Page | null
-const page = penpotUtils.getPageById("uuid"); // Page | null
+// Get Page object by name/id (full Page API)
+const pageByName = penpotUtils.getPageByName("Mobile"); // Page | null
+const pageById = penpotUtils.getPageById("uuid"); // Page | null
 
 // Current page
 const currentPage = penpot.currentPage; // Page | null
@@ -234,6 +247,8 @@ const currentPage = penpot.currentPage; // Page | null
 ```javascript
 // Criteria-based search on a specific page — cleaner than predicate on root
 const page = penpotUtils.getPageByName("Mobile");
+if (!page) return { error: "Page not found", pageName: "Mobile" };
+
 const boards = page.findShapes({ type: "board" });
 const named = page.findShapes({ name: "Header" });
 const like = page.findShapes({ nameLike: "btn-" });
@@ -707,7 +722,7 @@ function ensureSet(name) {
 // Idempotent token addition
 function addToken(set, type, name, value) {
   return (
-    set.tokens.find((t) => t.name === name) ||
+    set.tokens.find((t) => t.name === name && t.type === type) ||
     set.addToken({ type, name, value: String(value) })
   );
 }
@@ -826,7 +841,7 @@ const pages = penpotUtils.getPages().map((p) => {
   const page = penpotUtils.getPageByName(p.name);
   return {
     name: p.name,
-    boardCount: page.findShapes({ type: "board" }).length,
+    boardCount: page ? page.findShapes({ type: "board" }).length : 0,
   };
 });
 

--- a/penpot-mcp/references/prototyping-workflows.md
+++ b/penpot-mcp/references/prototyping-workflows.md
@@ -117,7 +117,7 @@ const sequence = [
 const boards = penpotUtils.findShapes((s) => s.type === "board", penpot.root);
 const ordered = sequence.map((name) => boards.find((b) => b.name === name));
 
-const missing = ordered.filter((b) => !b).map((_, i) => sequence[i]);
+const missing = sequence.filter((_, i) => !ordered[i]);
 if (missing.length > 0) return { error: "Missing boards", missing };
 
 const results = [];

--- a/penpot-mcp/references/prototyping-workflows.md
+++ b/penpot-mcp/references/prototyping-workflows.md
@@ -108,7 +108,12 @@ back.addInteraction("click", {
 
 ```javascript
 // Wire a sequence: boards must be in order
-const sequence = ["screen-1", "screen-2", "screen-3", "screen-4"];
+const sequence = [
+  "/screens/screen-1",
+  "/screens/screen-2",
+  "/screens/screen-3",
+  "/screens/screen-4",
+];
 const boards = penpotUtils.findShapes((s) => s.type === "board", penpot.root);
 const ordered = sequence.map((name) => boards.find((b) => b.name === name));
 
@@ -140,11 +145,21 @@ Use when: adding modals, tooltips, drawers, or confirmation dialogs.
 // Overlay boards should be sized to match their content, not the full screen
 // Position doesn't matter on canvas — Penpot positions them relative to trigger at runtime
 
+const sourceBoard = penpotUtils.findShape((s) => s.name === "/screens/settings");
+const boards = penpotUtils.findShapes((s) => s.type === "board", penpot.root);
 const modal = boards.find((b) => b.name === "overlay/confirm-delete");
-const trigger = penpotUtils.findShapes(
-  (s) => s.name === "btn-delete",
-  sourceboard,
-)[0];
+const trigger = sourceBoard
+  ? penpotUtils.findShapes((s) => s.name === "btn-delete", sourceBoard)[0]
+  : null;
+
+if (!modal || !trigger) {
+  return {
+    skipped: true,
+    reason: "Missing overlay board or trigger",
+    modal: Boolean(modal),
+    trigger: Boolean(trigger),
+  };
+}
 
 trigger.addInteraction("click", {
   type: "open-overlay",
@@ -284,13 +299,14 @@ const allBoards = penpotUtils.findShapes(
 );
 let removed = 0;
 // Batch: 5 boards at a time
-allBoards.slice(0, 5).forEach((board) => {
+const processed = allBoards.slice(0, 5);
+processed.forEach((board) => {
   (board.interactions || []).forEach((i) => {
     i.remove();
     removed++;
   });
 });
-return { removedCount: removed, remaining: Math.max(allBoards.length - 5, 0) };
+return { removedCount: removed, remaining: allBoards.length - processed.length };
 ```
 
 ---


### PR DESCRIPTION
## Summary
- Add explicit guardrails for community plugins: MCP cannot enumerate, install, launch, or drive arbitrary installed plugins through the documented Penpot MCP/plugin API.
- Document a safe coordination pattern: inspect via MCP first, use user-provided plugin inventories only as context, ask for confirmation before relying on a plugin, and avoid marketplace/browser plugins such as Plugins list unless explicitly requested.
- Address remaining still-valid PR #2 review items in examples: duplicate page variable, nullable page lookup, token idempotency by type, sequence naming, overlay guard/source variables, and reset remaining count.
- Add .npmignore/.gitignore coverage so local agent/workspace files do not get packed or accidentally committed.
- Add GitHub issue templates, PR template, CONTRIBUTING.md, SECURITY.md, README CI status badge, CodeQL workflow, and Dependabot config.
- Make format:check robust to Windows CRLF checkouts and include all GitHub YAML templates.

## Validation
- npm run validate: passed
- npm run format:check: passed
- npm run lint: passed
- npm run check:whitespace: passed
- git diff --check -- .github README.md package.json penpot-mcp scripts CONTRIBUTING.md SECURITY.md .gitignore .npmignore: passed
- npm pack --dry-run: passed; package contains 21 files and excludes local agent/workspace files

## Notes
- Verified plugin boundary wording against current Penpot MCP/tool docs and Penpot plugin manifest/API docs. The docs do not expose installed-plugin enumeration or an automation bus for arbitrary community plugins.
- CodeQL default setup is not configured in this repo, and no code scanning analysis existed; this PR adds an explicit CodeQL workflow so the required CodeQL check can report.
- Dependabot is configured for weekly npm and GitHub Actions updates.
- Prior maintainer report was saved locally to C:\Users\ar271\.openclaw\workspace\penpot-mcp-pr4-report-2026-05-27.md.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR is a documentation-only change that adds community plugin guardrails to the Penpot MCP skill, fixes several code examples in reference files, and adds standard GitHub repository infrastructure (issue templates, PR template, CodeQL workflow, dependabot, CONTRIBUTING.md, SECURITY.md).

- **Community plugin guardrails** are added to both `SKILL.md` and `penpot-api-patterns.md`, clearly documenting that MCP cannot enumerate, install, or drive arbitrary installed plugins and providing a safe coordination pattern for agents.
- **Code example fixes** in `penpot-api-patterns.md` and `prototyping-workflows.md` address a duplicate `page` variable shadowing, a missing null guard on `page.findShapes()`, a token idempotency bug (matching only by name, not name+type), a broken missing-board filter index mapping, a missing `sourceBoard`/`trigger` guard, and a hardcoded batch-size constant in the remaining-count calculation.
- **Repository infrastructure** (issue templates, CodeQL, dependabot, `.npmignore`) follows GitHub best practices and uses pinned-SHA action references for supply-chain safety.

<h3>Confidence Score: 5/5</h3>

This PR is safe to merge — all changes are documentation, configuration, and code example corrections with no runtime-executed code paths.

Every changed file is either Markdown skill documentation, GitHub repository configuration, or a package.json script tweak. The code-example fixes (null guards, idempotency, index mapping) are straightforward improvements to documentation snippets. The new GitHub Actions workflow pins action SHAs and uses minimal permissions, following supply-chain best practices. No logic that executes at runtime was added or modified.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| penpot-mcp/references/penpot-api-patterns.md | Fixes duplicate `page` variable shadowing, adds null guard before `findShapes`, fixes token idempotency to match name+type instead of name-only, adds null guard in boardCount map, and documents community plugin boundaries. |
| penpot-mcp/references/prototyping-workflows.md | Fixes a broken missing-board filter (wrong index mapping in filter+map chain), adds sourceBoard/modal/trigger null guards in overlay setup, and corrects remaining-count calculation to use processed.length instead of a hardcoded 5. |
| penpot-mcp/SKILL.md | Adds community plugin guardrails section clearly scoping what MCP can and cannot do with installed plugins. |
| .github/workflows/codeql.yml | New CodeQL workflow with pinned SHAs, minimal permissions, and `persist-credentials: false` — follows supply-chain hardening best practices. |
| package.json | Expands format:check glob from workflows/**/*.yml to .github/**/*.yml to cover new templates/dependabot, and adds --end-of-line auto for Windows CRLF tolerance. |
| .gitignore | Adds workspace-specific agent files (.openclaw/, AGENTS.md, SOUL.md, etc.) and *.tgz pack artifacts to gitignore. |
| .npmignore | New file mirroring .gitignore entries, ensuring local agent/workspace files are excluded from npm pack output. |
| CONTRIBUTING.md | New contributing guide documenting core invariants, local workflow steps, and PR expectations — well-aligned with skill content rules. |
| SECURITY.md | New security policy with clearly defined in/out of scope items and contributor expectations; correctly defers Penpot/MCP server issues to their respective maintainers. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Agent task involving a plugin] --> B{File-visible evidence?}
    B -- Yes --> C[Inspect via MCP\npenpot_api_info / high_level_overview]
    B -- No --> C
    C --> D{User provided\nplugin inventory?}
    D -- Yes --> E[Match task to plugin\ncapability from inventory]
    D -- No --> F[Use MCP-native\nreads/writes]
    E --> G{Task clearly maps\nto plugin?}
    G -- Yes --> H[Ask user to confirm\nplugin and intent]
    G -- No --> F
    H --> I{Plugin needs\nown UI/permissions?}
    I -- Yes --> J[Ask user to run\nplugin manually]
    I -- No --> K[Proceed with\nplugin coordination]
    J --> L[Re-inspect file\nwith MCP]
    L --> F
    F --> M[Complete task]
    K --> M
```

<sub>Reviews (4): Last reviewed commit: ["ci: add Dependabot updates"](https://github.com/ar27111994/penpot-mcp/commit/b4c59534f0dd8da7403c4a6a8419153a201999ff) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34209790)</sub>

<!-- /greptile_comment -->