### PR TITLE
Add trigger validation and skill metadata for v1.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+All notable changes to this community skill are documented here.
+
+## 1.5.2 - 2026-05-28
+
+- Added skill frontmatter metadata for version, category, tags, and compatibility.
+- Tightened trigger wording to focus on Penpot-agent workflows instead of any Penpot mention.
+- Clarified local `/mcp` vs `/sse` usage and the `Already connected to a transport` troubleshooting path.
+- Added an `uploadMediaUrl` trust warning for URL-based image imports.
+
+## 1.5.1 - 2026-05-28
+
+- Fixed README badge validation to parse badge URLs safely and satisfy CodeQL URL-sanitization checks.
+
+## 1.5.0 - 2026-05-28
+
+- Added public repository maintenance files, security reporting guidance, validation CI, CodeQL, Dependabot, and package validation improvements.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this community skill are documented here.
 - Tightened trigger wording to focus on Penpot-agent workflows instead of any Penpot mention.
 - Clarified local `/mcp` vs `/sse` usage and the `Already connected to a transport` troubleshooting path.
 - Added an `uploadMediaUrl` trust warning for URL-based image imports.
+- Added Markdown JavaScript snippet validation for common Penpot API anti-patterns.
 
 ## 1.5.1 - 2026-05-28
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Works with any MCP-compatible client: **Claude Code**, **Cursor**, **VS Code / C
 
 ## What this skill covers
 
-- **Remote & local MCP setup** — up-to-date configs for all major MCP clients; Remote MCP recommended for most users
+- **Remote & local MCP setup** — up-to-date configs for all major MCP clients; Remote MCP recommended for most users; `/sse` fallback guidance for local transport conflicts
 - **All 5 MCP tools** — `execute_code`, `high_level_overview`, `penpot_api_info`, `export_shape`, `import_image`
 - **Penpot JS API patterns** — `penpotUtils` reference, read-only property gotchas, flex ordering quirks, board positioning, CSS export, plugin data API, community plugin boundaries
 - **Font & typography constraints** — installed variant detection, library vs. layer fontSize types, stale `fontId` limitation
@@ -72,6 +72,10 @@ Key differences:
 - ✅ **Write safety**: batch limits, page-switch two-call pattern, export reliability gotcha
 - ✅ **Prototyping workflows**: flows, overlays, multi-flow, animation guide
 - ✅ Compatible with **all MCP-compatible agents**, not just Claude Code or Cursor
+
+## Changelog
+
+See [CHANGELOG.md](CHANGELOG.md) for release notes.
 
 ## Contributing
 

--- a/evals/trigger-tests.json
+++ b/evals/trigger-tests.json
@@ -1,0 +1,14 @@
+{
+  "positive": [
+    "Set up Penpot MCP in VS Code for this design file.",
+    "Use Penpot MCP to audit the design tokens in my file.",
+    "Create prototype interactions and overlays in Penpot with an AI agent.",
+    "Export assets from a Penpot design and map them to React components."
+  ],
+  "negative": [
+    "What is Penpot?",
+    "Compare Penpot and Figma at a high level.",
+    "Write a blog intro about open-source design tools.",
+    "Summarize the history of vector graphics editors."
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "penpot-mcp",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "penpot-mcp",
-      "version": "1.5.1",
+      "version": "1.5.2",
       "license": "MIT",
       "devDependencies": {
         "eslint": "^10.4.0",

--- a/package.json
+++ b/package.json
@@ -5,9 +5,10 @@
   "scripts": {
     "lint": "eslint \"scripts/**/*.mjs\" eslint.config.mjs",
     "format:check": "prettier --check package.json package-lock.json eslint.config.mjs scripts/**/*.mjs .github/**/*.yml --end-of-line auto",
-    "validate": "node scripts/validate-package.mjs && node scripts/check-trigger-evals.mjs",
+    "validate": "node scripts/validate-package.mjs && node scripts/check-trigger-evals.mjs && node scripts/check-snippets.mjs",
     "check:whitespace": "git diff --check -- .github README.md package.json penpot-mcp scripts && git diff --cached --check -- .github README.md package.json penpot-mcp scripts",
-    "eval:triggers": "node scripts/check-trigger-evals.mjs"
+    "eval:triggers": "node scripts/check-trigger-evals.mjs",
+    "check:snippets": "node scripts/check-snippets.mjs"
   },
   "author": "ar27111994",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,12 +1,13 @@
 {
   "name": "penpot-mcp",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "AI-agent skill for creating, auditing, and maintaining production-grade Penpot design projects, design systems, flows, interactions, animations, tokens, and visual effects via the official Penpot MCP Server.",
   "scripts": {
     "lint": "eslint \"scripts/**/*.mjs\" eslint.config.mjs",
     "format:check": "prettier --check package.json package-lock.json eslint.config.mjs scripts/**/*.mjs .github/**/*.yml --end-of-line auto",
-    "validate": "node scripts/validate-package.mjs",
-    "check:whitespace": "git diff --check -- .github README.md package.json penpot-mcp scripts && git diff --cached --check -- .github README.md package.json penpot-mcp scripts"
+    "validate": "node scripts/validate-package.mjs && node scripts/check-trigger-evals.mjs",
+    "check:whitespace": "git diff --check -- .github README.md package.json penpot-mcp scripts && git diff --cached --check -- .github README.md package.json penpot-mcp scripts",
+    "eval:triggers": "node scripts/check-trigger-evals.mjs"
   },
   "author": "ar27111994",
   "license": "MIT",

--- a/penpot-mcp/SKILL.md
+++ b/penpot-mcp/SKILL.md
@@ -3,7 +3,7 @@ name: penpot-mcp
 version: "1.5.2"
 category: design
 tags: [penpot, mcp, design-system, prototyping, design-to-code, tokens, interactions]
-compatibility: claude-code, cursor, codex, windsurf, cline, amp
+compatibility: claude-code, cursor, vscode, copilot, codex, windsurf, cline, amp, claude-desktop
 description: >
   Use this skill whenever the user wants to use AI agents to work with Penpot design files via
   the Penpot MCP Server. Triggers include: using Penpot through an AI agent, design files,

--- a/penpot-mcp/SKILL.md
+++ b/penpot-mcp/SKILL.md
@@ -1,15 +1,19 @@
 ---
 name: penpot-mcp
+version: "1.5.2"
+category: design
+tags: [penpot, mcp, design-system, prototyping, design-to-code, tokens, interactions]
+compatibility: claude-code, cursor, codex, windsurf, cline, amp
 description: >
   Use this skill whenever the user wants to use AI agents to work with Penpot design files via
-  the Penpot MCP Server. Triggers include: any mention of Penpot, design files, design systems,
-  design tokens, Penpot MCP, design-to-code, generating UI from design, auditing a design system,
-  creating components/variants, renaming layers, exporting assets from Penpot, adding flows,
-  interactions, animations, overlays, or prototyping in Penpot, or prompting an AI agent to
-  read/modify a Penpot file. Also triggers when the user wants to set up Penpot MCP, connect
-  any MCP-compatible AI agent or IDE to Penpot, or produce production-ready HTML/CSS/React from
-  a Penpot design. Use this skill for ALL Penpot-agent workflows — design, code, audit,
-  prototyping, or setup.
+  the Penpot MCP Server. Triggers include: using Penpot through an AI agent, design files,
+  design systems, design tokens, Penpot MCP, design-to-code, generating UI from design,
+  auditing a design system, creating components/variants, renaming layers, exporting assets
+  from Penpot, adding flows, interactions, animations, overlays, or prototyping in Penpot,
+  or prompting an AI agent to read/modify a Penpot file. Also triggers when the user wants
+  to set up Penpot MCP, connect any MCP-compatible AI agent or IDE to Penpot, or produce
+  production-ready HTML/CSS/React from a Penpot design. Use this skill for Penpot-agent
+  workflows — design, code, audit, prototyping, or setup.
 ---
 
 # Penpot MCP Skill
@@ -57,8 +61,8 @@ npx @penpot/mcp@beta     # for beta/test environments
 
 - Load plugin: **Plugins → Load from URL** → `http://localhost:4400/manifest.json`
 - Click **Connect to MCP server** in plugin UI → keep plugin window open at all times
-- Client URL: `http://localhost:4401/mcp` (no auth)
-- Legacy SSE fallback: `http://localhost:4401/sse`
+- Client URL: `http://localhost:4401/mcp` (no auth; preferred for single-client setups)
+- SSE fallback: `http://localhost:4401/sse` (use when `/mcp` transport conflicts occur, or with `mcp-remote` for stdio-only clients)
 
 ### Client Config Snippets
 
@@ -101,7 +105,7 @@ npx @penpot/mcp@beta     # for beta/test environments
 **Claude Desktop** (stdio-only — requires proxy):
 
 ```bash
-npx -y mcp-remote http://localhost:4401/mcp --allow-http
+npx -y mcp-remote http://localhost:4401/sse --allow-http
 ```
 
 ### Troubleshooting Checklist
@@ -109,6 +113,7 @@ npx -y mcp-remote http://localhost:4401/mcp --allow-http
 - Restart MCP server process
 - Reconnect plugin (**File → MCP Server → Connect**)
 - Restart MCP client / reload tools
+- `Error: Already connected to a transport` → close other MCP clients; use `/sse` fallback if `/mcp` conflicts
 - Keep plugin window open while agents run at all times
 - Firefox preferred if Chromium blocks `localhost` from `https://design.penpot.app`
 - Expired MCP key → regenerate in Penpot → Integrations; update all client configs
@@ -403,18 +408,19 @@ and a drop shadow. Describe the values you'll use before applying."
 
 **MCP/infrastructure:**
 
-| Gotcha                                  | Mitigation                                         |
-| --------------------------------------- | -------------------------------------------------- |
-| MCP acts on focused page only           | Confirm page focus before each write batch         |
-| Write ops immediate — no undo via MCP   | Plan + describe before applying                    |
-| Large batches time out silently         | Max ~10 ops per call; verify after each            |
-| Page switch is async                    | Never switch page and write in same call           |
-| `export_shape` may fail with HTTP error | Verify structurally via API; export is best-effort |
-| Remote MCP can't read local file system | Use local MCP for `import_image`                   |
-| Only one active MCP tab                 | Close other Penpot tabs before running agents      |
-| MCP key shown only once                 | Copy immediately; regenerate if lost               |
-| Expired key blocks all connections      | Regenerate in Integrations; update all configs     |
-| Chromium ≥142 blocks localhost          | Use Firefox, or allow local network explicitly     |
+| Gotcha                                    | Mitigation                                                     |
+| ----------------------------------------- | -------------------------------------------------------------- |
+| MCP acts on focused page only             | Confirm page focus before each write batch                     |
+| Write ops immediate — no undo via MCP     | Plan + describe before applying                                |
+| Large batches time out silently           | Max ~10 ops per call; verify after each                        |
+| Page switch is async                      | Never switch page and write in same call                       |
+| `export_shape` may fail with HTTP error   | Verify structurally via API; export is best-effort             |
+| Remote MCP can't read local file system   | Use local MCP for `import_image`                               |
+| Only one active MCP tab                   | Close other Penpot tabs before running agents                  |
+| `Error: Already connected to a transport` | Close other MCP clients; use `/sse` fallback if `/mcp` conflicts |
+| MCP key shown only once                   | Copy immediately; regenerate if lost                           |
+| Expired key blocks all connections        | Regenerate in Integrations; update all configs                 |
+| Chromium ≥142 blocks localhost            | Use Firefox, or allow local network explicitly                 |
 
 **Penpot plugin API (full detail → `references/penpot-api-patterns.md`):**
 

--- a/penpot-mcp/references/penpot-api-patterns.md
+++ b/penpot-mcp/references/penpot-api-patterns.md
@@ -78,6 +78,7 @@ board.interactions; // Interaction[]
 const board = penpot.createBoard();
 const rect = penpot.createRectangle();
 const text = penpot.createText("Hello"); // returns Text | null
+if (!text) return { error: "createText returned null" };
 const ellipse = penpot.createEllipse();
 
 // Layout on a container

--- a/penpot-mcp/references/penpot-api-patterns.md
+++ b/penpot-mcp/references/penpot-api-patterns.md
@@ -583,6 +583,8 @@ shape.fills = [
 
 ### Image fill (from URL)
 
+`uploadMediaUrl(name, url)` fetches from the URL via the Penpot server. Only use URLs from trusted sources — never pass user-supplied or agent-generated URLs without validation.
+
 ```javascript
 // uploadMediaUrl is async — must use await
 const imageData = await penpot.uploadMediaUrl(

--- a/scripts/check-snippets.mjs
+++ b/scripts/check-snippets.mjs
@@ -17,9 +17,24 @@ function fail(message) {
   failures.push(message);
 }
 
-/** Reads a UTF-8 file from a repository-relative path. */
+/** Reads a UTF-8 Markdown file from a repository-relative path. */
 function readRepositoryFile(filePath) {
-  return readFileSync(join(repositoryRoot, filePath), "utf8");
+  try {
+    return readFileSync(join(repositoryRoot, filePath), "utf8");
+  } catch (error) {
+    if (error.code === "ENOENT") {
+      fail(`Missing markdown file: ${filePath}`);
+    } else {
+      fail(`Could not read markdown file ${filePath}: ${error.message}`);
+    }
+
+    return null;
+  }
+}
+
+/** Escapes user-provided text for literal use inside a RegExp. */
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 /** Extracts fenced JavaScript code blocks with starting line numbers. */
@@ -53,21 +68,55 @@ function collectJavaScriptBlocks(markdown) {
   return blocks;
 }
 
+/** Removes a line comment while preserving // inside strings such as URLs. */
+function stripLineComment(line) {
+  let quote = null;
+  let escaped = false;
+
+  for (let index = 0; index < line.length - 1; index += 1) {
+    const character = line[index];
+    const nextCharacter = line[index + 1];
+
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+
+    if (quote && character === "\\") {
+      escaped = true;
+      continue;
+    }
+
+    if (quote) {
+      if (character === quote) quote = null;
+      continue;
+    }
+
+    if (["'", '"', "`"].includes(character)) {
+      quote = character;
+      continue;
+    }
+
+    if (character === "/" && nextCharacter === "/") {
+      return line.slice(0, index);
+    }
+  }
+
+  return line;
+}
+
 /** Removes comments to reduce false positives in executable checks. */
 function stripComments(code) {
   return code
     .replace(/\/\*[\s\S]*?\*\//g, "")
     .split(/\r?\n/)
-    .map((line) => line.replace(/\/\/.*$/g, ""))
+    .map(stripLineComment)
     .join("\n");
 }
 
 /** Returns snippet lines that are not explicitly marked as bad examples. */
 function executableExampleLines(block) {
-  return block.code
-    .split(/\r?\n/)
-    .filter((line) => !line.includes("❌"))
-    .map((line) => line.replace(/\/\/.*$/g, ""));
+  return block.code.split(/\r?\n/).filter((line) => !line.includes("❌"));
 }
 
 /** Finds variables assigned from penpot.createText(...). */
@@ -77,10 +126,40 @@ function collectCreatedTextVariables(code) {
     /(?:const|let|var)\s+(\w+)\s*=\s*penpot\.createText\s*\(/g;
 
   for (const match of code.matchAll(createTextPattern)) {
-    textVariables.push(match[1]);
+    textVariables.push({
+      name: match[1],
+      declarationIndex: match.index,
+      afterDeclarationIndex: match.index + match[0].length,
+    });
   }
 
   return textVariables;
+}
+
+/** Finds the first match index for a pattern at or after startIndex. */
+function findMatchIndex(code, pattern, startIndex = 0) {
+  const match = pattern.exec(code.slice(startIndex));
+  return match ? startIndex + match.index : -1;
+}
+
+/** Finds the first recognized null guard for a variable after declaration. */
+function findNullGuardIndex(code, variableName, startIndex) {
+  const escapedName = escapeRegExp(variableName);
+  const guardPatterns = [
+    new RegExp(`if\\s*\\(\\s*!${escapedName}\\s*\\)`),
+    new RegExp(
+      `if\\s*\\(\\s*${escapedName}\\s*(?:==|===)\\s*(?:null|undefined)\\s*\\)`,
+    ),
+    new RegExp(
+      `if\\s*\\(\\s*(?:null|undefined)\\s*(?:==|===)\\s*${escapedName}\\s*\\)`,
+    ),
+  ];
+
+  const guardIndexes = guardPatterns
+    .map((pattern) => findMatchIndex(code, pattern, startIndex))
+    .filter((index) => index !== -1);
+
+  return guardIndexes.length === 0 ? -1 : Math.min(...guardIndexes);
 }
 
 /** Validates one JavaScript snippet for known Penpot API anti-patterns. */
@@ -102,18 +181,39 @@ function validateSnippet(filePath, block) {
   }
 
   const textVariables = collectCreatedTextVariables(executableCode);
-  for (const variableName of textVariables) {
-    const nullGuardPattern = new RegExp(`if\\s*\\(\\s*!${variableName}\\s*\\)`);
-    if (!nullGuardPattern.test(executableCode)) {
+  for (const textVariable of textVariables) {
+    const variableName = textVariable.name;
+    const escapedName = escapeRegExp(variableName);
+    const firstUseIndex = findMatchIndex(
+      executableCode,
+      new RegExp(`\\b${escapedName}\\s*\\.`),
+      textVariable.afterDeclarationIndex,
+    );
+    const nullGuardIndex = findNullGuardIndex(
+      executableCode,
+      variableName,
+      textVariable.afterDeclarationIndex,
+    );
+
+    if (nullGuardIndex === -1) {
       fail(`${location} calls penpot.createText(...) without a null guard`);
+    } else if (firstUseIndex !== -1 && nullGuardIndex > firstUseIndex) {
+      fail(`${location} uses ${variableName} before its null guard`);
     }
 
-    const textResizePattern = new RegExp(`\\b${variableName}\\.resize\\s*\\(`);
-    const growTypePattern = new RegExp(`\\b${variableName}\\.growType\\s*=`);
-    if (
-      textResizePattern.test(executableCode) &&
-      !growTypePattern.test(executableCode)
-    ) {
+    const textResizeIndex = findMatchIndex(
+      executableCode,
+      new RegExp(`\\b${escapedName}\\.resize\\s*\\(`),
+      textVariable.afterDeclarationIndex,
+    );
+    if (textResizeIndex === -1) continue;
+
+    const growTypeIndex = findMatchIndex(
+      executableCode,
+      new RegExp(`\\b${escapedName}\\.growType\\s*=`),
+      textResizeIndex,
+    );
+    if (growTypeIndex === -1) {
       fail(`${location} resizes ${variableName} without resetting growType`);
     }
   }
@@ -121,6 +221,8 @@ function validateSnippet(filePath, block) {
 
 for (const filePath of markdownFiles) {
   const markdown = readRepositoryFile(filePath);
+  if (markdown === null) continue;
+
   for (const block of collectJavaScriptBlocks(markdown)) {
     validateSnippet(filePath, block);
   }

--- a/scripts/check-snippets.mjs
+++ b/scripts/check-snippets.mjs
@@ -1,0 +1,135 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repositoryRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+const markdownFiles = [
+  "penpot-mcp/SKILL.md",
+  "penpot-mcp/references/penpot-api-patterns.md",
+  "penpot-mcp/references/design-system-workflows.md",
+  "penpot-mcp/references/design-to-code-workflows.md",
+  "penpot-mcp/references/prototyping-workflows.md",
+];
+const failures = [];
+
+/** Records a snippet validation failure. */
+function fail(message) {
+  failures.push(message);
+}
+
+/** Reads a UTF-8 file from a repository-relative path. */
+function readRepositoryFile(filePath) {
+  return readFileSync(join(repositoryRoot, filePath), "utf8");
+}
+
+/** Extracts fenced JavaScript code blocks with starting line numbers. */
+function collectJavaScriptBlocks(markdown) {
+  const blocks = [];
+  const lines = markdown.split(/\r?\n/);
+  let activeBlock = null;
+
+  lines.forEach((line, index) => {
+    const fenceMatch = line.match(/^```(\S*)?\s*$/);
+    if (!fenceMatch) {
+      if (activeBlock) activeBlock.lines.push(line);
+      return;
+    }
+
+    if (!activeBlock) {
+      const language = (fenceMatch[1] || "").toLowerCase();
+      if (["js", "javascript"].includes(language)) {
+        activeBlock = { startLine: index + 1, lines: [] };
+      }
+      return;
+    }
+
+    blocks.push({
+      startLine: activeBlock.startLine,
+      code: activeBlock.lines.join("\n"),
+    });
+    activeBlock = null;
+  });
+
+  return blocks;
+}
+
+/** Removes comments to reduce false positives in executable checks. */
+function stripComments(code) {
+  return code
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .split(/\r?\n/)
+    .map((line) => line.replace(/\/\/.*$/g, ""))
+    .join("\n");
+}
+
+/** Returns snippet lines that are not explicitly marked as bad examples. */
+function executableExampleLines(block) {
+  return block.code
+    .split(/\r?\n/)
+    .filter((line) => !line.includes("❌"))
+    .map((line) => line.replace(/\/\/.*$/g, ""));
+}
+
+/** Finds variables assigned from penpot.createText(...). */
+function collectCreatedTextVariables(code) {
+  const textVariables = [];
+  const createTextPattern =
+    /(?:const|let|var)\s+(\w+)\s*=\s*penpot\.createText\s*\(/g;
+
+  for (const match of code.matchAll(createTextPattern)) {
+    textVariables.push(match[1]);
+  }
+
+  return textVariables;
+}
+
+/** Validates one JavaScript snippet for known Penpot API anti-patterns. */
+function validateSnippet(filePath, block) {
+  const executableCode = stripComments(
+    executableExampleLines(block).join("\n"),
+  );
+  const location = `${filePath}:${block.startLine}`;
+
+  if (
+    /\b\w+\.width\s*=/.test(executableCode) ||
+    /\b\w+\.height\s*=/.test(executableCode)
+  ) {
+    fail(`${location} assigns width/height directly; use resize(w, h)`);
+  }
+
+  if (/\b\w+\.fillColor\s*=/.test(executableCode)) {
+    fail(`${location} assigns fillColor directly; library colors use .color`);
+  }
+
+  const textVariables = collectCreatedTextVariables(executableCode);
+  for (const variableName of textVariables) {
+    const nullGuardPattern = new RegExp(`if\\s*\\(\\s*!${variableName}\\s*\\)`);
+    if (!nullGuardPattern.test(executableCode)) {
+      fail(`${location} calls penpot.createText(...) without a null guard`);
+    }
+
+    const textResizePattern = new RegExp(`\\b${variableName}\\.resize\\s*\\(`);
+    const growTypePattern = new RegExp(`\\b${variableName}\\.growType\\s*=`);
+    if (
+      textResizePattern.test(executableCode) &&
+      !growTypePattern.test(executableCode)
+    ) {
+      fail(`${location} resizes ${variableName} without resetting growType`);
+    }
+  }
+}
+
+for (const filePath of markdownFiles) {
+  const markdown = readRepositoryFile(filePath);
+  for (const block of collectJavaScriptBlocks(markdown)) {
+    validateSnippet(filePath, block);
+  }
+}
+
+if (failures.length > 0) {
+  console.error("Snippet validation failed:");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log("Snippet validation passed");

--- a/scripts/check-trigger-evals.mjs
+++ b/scripts/check-trigger-evals.mjs
@@ -1,0 +1,93 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repositoryRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+const failures = [];
+
+function fail(message) {
+  failures.push(message);
+}
+
+function readRepositoryFile(filePath) {
+  return readFileSync(join(repositoryRoot, filePath), "utf8");
+}
+
+function readJson(filePath) {
+  try {
+    return JSON.parse(readRepositoryFile(filePath));
+  } catch (error) {
+    fail(`${filePath} is not valid JSON: ${error.message}`);
+    return null;
+  }
+}
+
+function collectFrontmatterDescription(skill) {
+  const match = skill.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!match) return "";
+
+  const lines = match[1].split(/\r?\n/);
+  const descriptionLines = [];
+  let inDescription = false;
+
+  for (const line of lines) {
+    if (line.startsWith("description:")) {
+      inDescription = true;
+      const inlineValue = line.slice("description:".length).trim();
+      if (inlineValue && inlineValue !== ">" && inlineValue !== "|") {
+        descriptionLines.push(inlineValue);
+      }
+      continue;
+    }
+
+    if (inDescription && /^[A-Za-z0-9_-]+:\s*/.test(line)) break;
+    if (inDescription && line.trim()) descriptionLines.push(line.trim());
+  }
+
+  return descriptionLines.join(" ").toLowerCase();
+}
+
+function validateTriggerEvals() {
+  const evals = readJson("evals/trigger-tests.json");
+  if (!evals) return;
+
+  for (const section of ["positive", "negative"]) {
+    if (!Array.isArray(evals[section]) || evals[section].length === 0) {
+      fail(
+        `evals/trigger-tests.json must include a non-empty ${section} array`,
+      );
+    }
+  }
+
+  const description = collectFrontmatterDescription(
+    readRepositoryFile("penpot-mcp/SKILL.md"),
+  );
+
+  if (description.includes("any mention of penpot")) {
+    fail(
+      "SKILL.md trigger description is too broad: contains 'any mention of Penpot'",
+    );
+  }
+
+  if (
+    !description.includes("ai agent") ||
+    !description.includes("penpot mcp")
+  ) {
+    fail("SKILL.md trigger description must mention AI-agent Penpot MCP usage");
+  }
+
+  const negativePrompts = evals.negative.join("\n").toLowerCase();
+  if (!negativePrompts.includes("what is penpot")) {
+    fail("Trigger evals must include a negative informational Penpot prompt");
+  }
+}
+
+validateTriggerEvals();
+
+if (failures.length > 0) {
+  console.error("Trigger eval validation failed:");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log("Trigger eval validation passed");

--- a/scripts/check-trigger-evals.mjs
+++ b/scripts/check-trigger-evals.mjs
@@ -5,14 +5,17 @@ import { fileURLToPath } from "node:url";
 const repositoryRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
 const failures = [];
 
+/** Records a validation failure without stopping later checks. */
 function fail(message) {
   failures.push(message);
 }
 
+/** Reads a UTF-8 file from a repository-relative path. */
 function readRepositoryFile(filePath) {
   return readFileSync(join(repositoryRoot, filePath), "utf8");
 }
 
+/** Reads and parses a JSON file from the repository. */
 function readJson(filePath) {
   try {
     return JSON.parse(readRepositoryFile(filePath));
@@ -22,6 +25,7 @@ function readJson(filePath) {
   }
 }
 
+/** Extracts the folded frontmatter description from SKILL.md. */
 function collectFrontmatterDescription(skill) {
   const match = skill.match(/^---\r?\n([\s\S]*?)\r?\n---/);
   if (!match) return "";
@@ -47,17 +51,22 @@ function collectFrontmatterDescription(skill) {
   return descriptionLines.join(" ").toLowerCase();
 }
 
+/** Validates trigger eval examples and the SKILL.md trigger description. */
 function validateTriggerEvals() {
   const evals = readJson("evals/trigger-tests.json");
   if (!evals) return;
 
+  let hasInvalidSection = false;
   for (const section of ["positive", "negative"]) {
     if (!Array.isArray(evals[section]) || evals[section].length === 0) {
       fail(
         `evals/trigger-tests.json must include a non-empty ${section} array`,
       );
+      hasInvalidSection = true;
     }
   }
+
+  if (hasInvalidSection) return;
 
   const description = collectFrontmatterDescription(
     readRepositoryFile("penpot-mcp/SKILL.md"),

--- a/scripts/validate-package.mjs
+++ b/scripts/validate-package.mjs
@@ -255,7 +255,7 @@ function validateSkillFrontmatter(packageJson) {
 function validateRequiredFiles() {
   for (const filePath of [...requiredReferenceFiles, ...requiredPackageFiles]) {
     if (!existsSync(repositoryPath(filePath))) {
-      fail(`Required package file is missing: ${filePath}`);
+      fail(`Required file is missing: ${filePath}`);
     }
   }
 }

--- a/scripts/validate-package.mjs
+++ b/scripts/validate-package.mjs
@@ -11,6 +11,7 @@ const requiredReferenceFiles = [
   "penpot-mcp/references/design-to-code-workflows.md",
   "penpot-mcp/references/prototyping-workflows.md",
 ];
+const requiredPackageFiles = ["CHANGELOG.md", "evals/trigger-tests.json"];
 
 const skippedDirectories = new Set([".git", "node_modules"]);
 const textFileExtensions = new Set([".json", ".md", ".mjs", ".yml", ".yaml"]);
@@ -204,7 +205,7 @@ function validateReadmeVersionBadge(packageJson) {
 }
 
 /** Validates the skill discovery frontmatter required by agent clients. */
-function validateSkillFrontmatter() {
+function validateSkillFrontmatter(packageJson) {
   const skill = readRepositoryFile("penpot-mcp/SKILL.md");
   const frontmatterMatch = skill.match(/^---\r?\n([\s\S]*?)\r?\n---/);
 
@@ -215,10 +216,34 @@ function validateSkillFrontmatter() {
 
   const frontmatter = frontmatterMatch[1];
   const name = readFrontmatterValue(frontmatter, "name");
+  const version = readFrontmatterValue(frontmatter, "version");
+  const category = readFrontmatterValue(frontmatter, "category");
+  const tags = readFrontmatterValue(frontmatter, "tags");
+  const compatibility = readFrontmatterValue(frontmatter, "compatibility");
   const description = readFrontmatterValue(frontmatter, "description");
 
   if (name !== "penpot-mcp") {
     fail("penpot-mcp/SKILL.md frontmatter name must be penpot-mcp");
+  }
+
+  if (!version || !semverPattern.test(version)) {
+    fail("penpot-mcp/SKILL.md frontmatter version must be valid semver");
+  } else if (packageJson && version !== packageJson.version) {
+    fail(
+      `penpot-mcp/SKILL.md frontmatter version ${version} does not match package.json ${packageJson.version}`,
+    );
+  }
+
+  if (category !== "design") {
+    fail("penpot-mcp/SKILL.md frontmatter category must be design");
+  }
+
+  if (!tags.startsWith("[") || !tags.endsWith("]")) {
+    fail("penpot-mcp/SKILL.md frontmatter tags must be an inline YAML list");
+  }
+
+  if (!compatibility) {
+    fail("penpot-mcp/SKILL.md frontmatter compatibility is required");
   }
 
   if (!description) {
@@ -226,11 +251,11 @@ function validateSkillFrontmatter() {
   }
 }
 
-/** Ensures all reference files advertised by the package exist. */
-function validateRequiredReferences() {
-  for (const filePath of requiredReferenceFiles) {
+/** Ensures all files advertised by the package exist. */
+function validateRequiredFiles() {
+  for (const filePath of [...requiredReferenceFiles, ...requiredPackageFiles]) {
     if (!existsSync(repositoryPath(filePath))) {
-      fail(`Required reference file is missing: ${filePath}`);
+      fail(`Required package file is missing: ${filePath}`);
     }
   }
 }
@@ -381,8 +406,8 @@ function validateTrailingWhitespace(filePath) {
 
 const packageJson = validatePackageJson();
 if (packageJson) validateReadmeVersionBadge(packageJson);
-validateSkillFrontmatter();
-validateRequiredReferences();
+validateSkillFrontmatter(packageJson);
+validateRequiredFiles();
 
 for (const filePath of collectTextFiles()) {
   validateTrailingWhitespace(filePath);


### PR DESCRIPTION
## Summary

- Add SKILL.md discovery metadata (`version`, `category`, `tags`, `compatibility`) and align it with package version 1.5.2.
- Tighten trigger wording and add trigger evals/validation to prevent broad "any Penpot mention" activation regressions.
- Clarify local `/mcp` vs `/sse` guidance, including the `Already connected to a transport` troubleshooting path.
- Add `uploadMediaUrl` trusted-URL warning and a minimal CHANGELOG.
- Harden trigger eval validation so malformed eval arrays report clean failures instead of throwing.
- Add Markdown JavaScript snippet validation for common Penpot API anti-patterns.

## Type of change

- [x] Documentation / skill content
- [ ] Reference workflow or example
- [x] Validation / packaging
- [x] Metadata / release prep
- [ ] Other:

## Penpot MCP safety checklist

- [x] I preserved inspect-first guidance (`penpot_api_info` / `high_level_overview`).
- [x] I preserved READ -> PLAN -> WRITE -> VERIFY guidance for modifications.
- [x] I kept write examples small and batched.
- [x] I avoided switching pages and writing in the same `execute_code` example.
- [x] I used structural verification instead of relying only on `export_shape`.
- [x] I avoided unsupported Penpot MCP/plugin behavior claims.
- [x] I kept examples generic and removed private/project-specific details.

## Validation

- [x] `npm run validate`
- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm run check:whitespace`
- [x] `npm pack --dry-run`

Additional whitespace check run:

- [x] `git diff --check -- .github README.md CHANGELOG.md package.json package-lock.json penpot-mcp scripts evals`

If any gate was skipped or failed, explain why:

- None skipped locally.

## Notes for reviewers

Verified audit items against current code before changing. The `penpot.createText(...)` null-guard finding was already present in the gotcha tables; this update also guards the concise create-shape snippet so the new snippet validator enforces the invariant going forward.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `/sse` fallback transport guidance for resolving MCP setup conflicts in VS Code
  * Enhanced troubleshooting documentation for transport connection issues

* **Documentation**
  * Clarified local `/mcp` vs remote `/sse` setup guidance with conflict resolution paths
  * Added security warnings for URL-based image imports and API validation best practices
  * Updated skill metadata for improved agent workflow targeting

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ar27111994/penpot-mcp/pull/6?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bumps the package to v1.5.2 and adds two new validation scripts (`check-trigger-evals.mjs`, `check-snippets.mjs`) alongside SKILL.md discovery metadata, a CHANGELOG, and updated documentation for the `/mcp` vs `/sse` transport guidance.

- **Trigger validation hardening**: The previously flagged crash on a malformed `trigger-tests.json` (non-array `negative` field) is correctly resolved via the `hasInvalidSection` early-return guard; `check-snippets.mjs` independently handles missing markdown files with `try/catch`.
- **Snippet anti-pattern validator**: Detects direct `width`/`height` assignment, missing `createText` null guards, and `resize` without a subsequent `growType` reset across all reference markdown files.
- **SKILL.md metadata + doc updates**: Adds `version`, `category`, `tags`, and `compatibility` frontmatter fields (validated against `package.json` version), tightens trigger wording, and adds the `Already connected to a transport` troubleshooting entry.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are documentation, metadata, and offline validation scripts with no runtime or API surface impact.

The crash bug called out in the previous review thread (non-array negative field causing a TypeError on evals.negative.join()) is correctly fixed with the hasInvalidSection early-return guard. The new snippet and trigger validators are self-contained scripts that only run during npm run validate, and the SKILL.md/CHANGELOG additions are purely additive. One ENOENT case in check-trigger-evals.mjs (missing SKILL.md) is still unguarded, but this is a dev-time convenience script and the scenario is unlikely in normal development.

scripts/check-trigger-evals.mjs — the SKILL.md read at line 71 has no error handling, unlike the equivalent pattern in check-snippets.mjs.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| scripts/check-trigger-evals.mjs | New validator for trigger eval arrays and SKILL.md description; fixes the previously flagged crash on malformed negative arrays, but readRepositoryFile at line 71–73 remains unguarded and will throw an unhandled ENOENT if SKILL.md is absent. |
| scripts/check-snippets.mjs | New validator for JavaScript snippets in markdown files; handles missing files via try/catch, correctly strips comments, and validates null-guard and growType patterns. |
| scripts/validate-package.mjs | Adds frontmatter version/category/tags/compatibility validation, wires SKILL.md version to package.json, and expands required-files check to cover CHANGELOG and evals; logic is sound. |
| penpot-mcp/SKILL.md | Adds version/category/tags/compatibility frontmatter, tightens trigger wording, clarifies /mcp vs /sse transport guidance, and updates the gotcha table with the Already connected to a transport row. |
| penpot-mcp/references/penpot-api-patterns.md | Adds null guard for createText and a security warning for uploadMediaUrl; both additions are correct and consistent with the existing gotcha documentation. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[npm run validate] --> B[validate-package.mjs]
    A --> C[check-trigger-evals.mjs]
    A --> D[check-snippets.mjs]

    B --> B1{package.json valid?}
    B1 -- yes --> B2[Validate README badge]
    B1 -- yes --> B3[Validate SKILL.md frontmatter]
    B1 -- yes --> B4[Validate required files]

    C --> C1{trigger-tests.json valid?}
    C1 -- yes --> C2[Read SKILL.md description]
    C2 --> C3{Trigger wording checks}
    C3 --> C4[Check negative prompts]

    D --> D1[Collect JS blocks from 5 markdown files]
    D1 --> D2{width/height direct assign?}
    D1 --> D3{createText without null guard?}
    D1 --> D4{resize without growType reset?}
    D1 --> D5{fillColor direct assign?}
```

<sub>Reviews (4): Last reviewed commit: ["fix: harden markdown snippet validation"](https://github.com/ar27111994/penpot-mcp/commit/b73b0c5f14ee5b32fd1705a1e2fd1404b260cbb6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34324717)</sub>

<!-- /greptile_comment -->