### PR TITLE
Expand Penpot MCP trigger eval examples

### DIFF
--- a/evals/trigger-tests.json
+++ b/evals/trigger-tests.json
@@ -1,17 +1,28 @@
 {
   "positive": [
     "Set up Penpot MCP in VS Code for this design file.",
+    "Troubleshoot a failed Penpot MCP remote connection in Cursor.",
     "Use Penpot MCP to audit the design tokens in my file.",
+    "Audit a Penpot design system for missing component states and token drift.",
     "Create prototype interactions and overlays in Penpot with an AI agent.",
+    "Build a Penpot prototype flow with modal overlays, drawers, and back navigation.",
     "Export assets from a Penpot design and map them to React components.",
     "Generate HTML and CSS from this Penpot frame using an AI agent.",
+    "Use Penpot MCP to extract design tokens and map a screen to reusable components.",
     "Wire up flow animations and transitions between boards in Penpot.",
-    "Build a design system from scratch in Penpot via MCP."
+    "Build a design system from scratch in Penpot via MCP.",
+    "Inspect my Penpot file before planning safe updates through MCP."
   ],
   "negative": [
     "What is Penpot?",
     "Compare Penpot and Figma at a high level.",
+    "How do I create a Penpot account?",
+    "List open-source alternatives to Penpot.",
     "Write a blog intro about open-source design tools.",
-    "Summarize the history of vector graphics editors."
+    "Summarize the history of vector graphics editors.",
+    "Explain what a design system is.",
+    "Suggest a color palette for a productivity dashboard.",
+    "What are modal overlays in product design?",
+    "Explain MCP at a high level without using any tools."
   ]
 }


### PR DESCRIPTION
## Summary

- add positive trigger examples for setup troubleshooting, design-system audits, prototyping flows/overlays, and Penpot-to-code workflows
- add negative trigger examples for generic Penpot, MCP, and UI/design questions that should not load the skill
- keep all examples generic and free of private project data

Closes #8.

## Type of change

- [x] Validation / packaging

## Penpot MCP safety checklist

- [x] I preserved inspect-first guidance (`penpot_api_info` / `high_level_overview`).
- [x] I preserved READ -> PLAN -> WRITE -> VERIFY guidance for modifications.
- [x] I kept write examples small and batched.
- [x] I avoided switching pages and writing in the same `execute_code` example.
- [x] I used structural verification instead of relying only on `export_shape`.
- [x] I avoided unsupported Penpot MCP/plugin behavior claims.
- [x] I kept examples generic and removed private/project-specific details.

## Validation

- [x] `npm run validate`
- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm run check:whitespace`
- [x] `npm run eval:triggers`
- [x] `npm pack --dry-run`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test cases for prompt trigger evaluation to include additional MCP-related scenarios and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR expands the trigger-eval fixture file with additional positive and negative prompt examples, improving coverage for the classifier that decides when to load the Penpot MCP skill.

- **Positive additions** cover setup troubleshooting, design-system audits, prototype flows, and design-to-code workflows — all phrased around active AI-agent usage of Penpot MCP.
- **Negative additions** cover generic Penpot account questions, conceptual design-system/UI explanations, and a bare MCP overview prompt — all questions that should not load the skill.
- The file remains valid JSON and continues to satisfy every check in `scripts/check-trigger-evals.mjs` (non-empty arrays, required negative "What is Penpot?" entry, no "any mention of penpot" overgeneralisation in SKILL.md).

<h3>Confidence Score: 5/5</h3>

Data-only change to a test fixtures file; no logic is modified and the existing validator script confirms the file remains well-formed.

The change is confined to a single JSON fixture file. The new examples are well-chosen: positive prompts consistently name Penpot MCP in an action context, and negative prompts cover realistic educational/generic questions that a user might ask without intending to invoke the skill. The validator (check-trigger-evals.mjs) continues to pass all structural and content checks.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| evals/trigger-tests.json | Adds 5 positive and 6 negative trigger examples; JSON is valid, all existing validator checks still pass, and the new examples cover meaningful edge-case categories (troubleshooting, design-system audit, generic MCP/design education). |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User Prompt] --> B{Trigger Classifier}
    B -->|positive match| C[Load Penpot MCP Skill]
    B -->|negative match| D[Skip / General Response]

    subgraph "New Positive Examples"
        P1["Troubleshoot Penpot MCP connection"]
        P2["Audit design system for token drift"]
        P3["Build prototype flow with overlays"]
        P4["Extract design tokens via MCP"]
        P5["Inspect file before MCP updates"]
    end

    subgraph "New Negative Examples"
        N1["How do I create a Penpot account?"]
        N2["List open-source design-tool alternatives"]
        N3["Explain what a design system is"]
        N4["Suggest a color palette"]
        N5["What are modal overlays? (concept)"]
        N6["Explain MCP at a high level"]
    end

    P1 & P2 & P3 & P4 & P5 -->|should trigger| C
    N1 & N2 & N3 & N4 & N5 & N6 -->|should not trigger| D
```

<sub>Reviews (1): Last reviewed commit: ["test: expand trigger eval examples"](https://github.com/ar27111994/penpot-mcp/commit/c0f60a1ad96da9bb6b48b1b4566a6b3311a2eecf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37466358)</sub>

<!-- /greptile_comment -->