### PR TITLE
docs: document two-call page switching and remove() instability in SKILL.md

### DIFF
--- a/penpot-mcp/SKILL.md
+++ b/penpot-mcp/SKILL.md
@@ -169,11 +169,15 @@ Before any setup steps, **call `penpot_api_info` or `high_level_overview` first*
 **Page switching — mandatory two-call pattern:**
 
 ```text
-Call N:   penpot.openPage(page)    ← switch page
-Call N+1: write/read on that page  ← write after switch
+Call N:   penpot.openPage(page)    ← switch page (currentPage still reports OLD page)
+Call N+1: any operation            ← now on new page; currentPage updated
 ```
 
-Page switching is asynchronous in the plugin bridge. Writing in the same call as `openPage` applies changes to the _previously_ active page. Exception: calling `openPage` at the top of a call then immediately reading (not writing) can be reliable.
+**CRITICAL:** `penpot.currentPage` does NOT update until the next tool call after `openPage()`. Writing shapes in the same call as `openPage()` silently applies them to the **previously** active page.
+
+**`remove()` is unreliable across calls** — Boards deleted via `shape.remove()` may reappear in subsequent structural queries (`getPages()` → `shapeStructure()`). The remove appears to succeed in the current call, but stale boards from previous sessions can reappear when the page structure is re-read.
+
+**Always verify the page before writing:** after `openPage()`, always make a lightweight read-only call first (e.g. return `penpot.currentPage?.name`) before creating any shapes.
 
 **Use `storage` for large workflows:**
 


### PR DESCRIPTION
## Summary

Fixes two critical documentation gaps discovered while building a production design system with self-hosted Penpot 2.16 + MCP:

### 1. `penpot.currentPage` is stale after `openPage()`

**Issue:** After calling `penpot.openPage(pageId)`, the `penpot.currentPage` property still reports the **previous** page until the next tool call. Writing to the canvas in the same call as `openPage()` silently applies changes to the wrong page — shapes land on the wrong page without any error.

**Fix:** Updated the skill to document the mandatory two-call pattern with an explicit verification step between navigation and writing.

### 2. `shape.remove()` is unreliable across calls

**Issue:** Boards deleted via `shape.remove()` may reappear on subsequent `getPages()` / `shapeStructure()` queries. The removal appears to succeed within the current call, but stale entries from previous sessions resurface when the page tree is re-read.

**Fix:** The skill now warns against relying on `remove()` for structural cleanup across tool calls.

## Changed file

- `penpot-mcp/SKILL.md` — expanded page-switching section with `currentPage` staleness warning and `remove()` instability note

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the Penpot MCP skill documentation for known bridge behavior. The main changes are:

- A stricter two-call page switching pattern after `openPage()`.
- A warning that `penpot.currentPage` remains stale until the next tool call.
- A warning that `shape.remove()` can leave stale boards visible in later structural queries.

<h3>Confidence Score: 4/5</h3>

The documentation changes need matching updates in the linked reference patterns before merging.

The new page-switch warning conflicts with examples that still read `currentPage` immediately after `openPage()`, and the new `remove()` warning conflicts with a rerun cleanup helper that still relies on `shape.remove()`.

penpot-mcp/SKILL.md and penpot-mcp/references/penpot-api-patterns.md

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Validated that the page-switch documentation now explicitly documents stale currentPage behavior after openPage and adds a lightweight read-only verification before creating shapes.
- Validated that the remove-instability documentation now includes the exact remove() instability warning and that the grep command exits with code 0.

<a href="https://app.greptile.com/trex/runs/13265922/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| penpot-mcp/SKILL.md | Documents page switching and removal caveats, but the new guidance conflicts with still-linked reference examples. |

<sub>Reviews (1): Last reviewed commit: ["docs: document two-call page switching a..."](https://github.com/ar27111994/penpot-mcp/commit/ab8669fa6f4b79ca01c240a370b2284b63d59b61) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41800988)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated workflow guidance for switching pages to make page changes safer and more predictable.
  * Added clearer warnings about writing content immediately after changing pages and about verifying the active page before making edits.
  * Included notes on unreliable delete behavior so users can avoid unexpected reappearing items during later edits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->